### PR TITLE
chore: harden live validation run pack and evidence workflow

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -46,6 +46,10 @@ Rule for completion: every `[x]` item includes evidence as one of:
   evidence: test `tests/SwfocTrainer.Tests/Profiles/LiveHeroHelperWorkflowTests.cs`
   evidence: manual `2026-02-15` `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --no-build` passed 69 tests, skipped 4 live-gated tests
 - [ ] Execute live-machine M1 validation run and attach evidence to issues `#34` and `#19`.
+  note: local attempt `2026-02-16` produced explicit skips because no live SWFOC process was running.
+  note: use `pwsh ./tools/run-live-validation.ps1 -Configuration Release -NoBuild` and post templates from `TestResults/` to `#34` and `#19`.
+  evidence-progress: `#34` comment `https://github.com/Prekzursil/SWFOC-Mod-Menu/issues/34#issuecomment-3905270711`
+  evidence-progress: `#19` comment `https://github.com/Prekzursil/SWFOC-Mod-Menu/issues/19#issuecomment-3905270874`
 - [x] Close/reconcile M0 carryover issues (`#15`, `#16`, `#17`, `#18`) with evidence comments.
   evidence: issue `https://github.com/Prekzursil/SWFOC-Mod-Menu/issues/15`
 - [x] Track plan archive under `(new)codex(plans)/` with explicit contributor convention.

--- a/docs/LIVE_VALIDATION_RUNBOOK.md
+++ b/docs/LIVE_VALIDATION_RUNBOOK.md
@@ -1,0 +1,55 @@
+# Live Validation Runbook (M1 Closure)
+
+Use this runbook to gather real-machine evidence for issues `#34` and `#19`.
+
+## 1. Preconditions
+
+- Launch the target game session first (`swfoc.exe` / `StarWarsG.exe`).
+- For AOTR: ensure workshop/mod launch context resolves to `aotr_1397421866_swfoc`.
+- For ROE: ensure launch context resolves to `roe_3447786229_swfoc`.
+- From repo root, run on Windows PowerShell.
+
+## 2. Run Pack Command
+
+```powershell
+pwsh ./tools/run-live-validation.ps1 -Configuration Release -NoBuild
+```
+
+Generated artifacts (under `TestResults/`):
+- `live-tactical.trx`
+- `live-hero-helper.trx`
+- `live-roe-health.trx`
+- `live-credits.trx`
+- `launch-context-fixture.json`
+- `live-validation-summary.json`
+- `issue-34-evidence-template.md`
+- `issue-19-evidence-template.md`
+
+`launch-context-fixture.json` behavior:
+- success path: full detector output JSON
+- fallback path: status payload (`failed`/`skipped`) with reason code when Python is unavailable in the current shell
+
+## 3. Post Evidence to GitHub Issues
+
+```powershell
+gh issue comment 34 --body-file TestResults/issue-34-evidence-template.md
+gh issue comment 19 --body-file TestResults/issue-19-evidence-template.md
+```
+
+Before posting, replace placeholder fields in each template with real attach/mode/profile details.
+Do not close issues from placeholder-only or skip-only runs.
+
+## 4. Closure Criteria
+
+Close issues only when all required evidence is present:
+- At least one successful tactical toggle + revert in tactical mode.
+- Helper workflow evidence for both AOTR and ROE.
+- Launch recommendation reason code + confidence captured.
+
+Then run:
+
+```powershell
+gh issue close 34 --comment "Live validation evidence posted; acceptance criteria met."
+gh issue close 19 --comment "AOTR/ROE live calibration checklist complete with evidence."
+gh issue close 7 --comment "All M1 acceptance criteria completed and evidenced across slices and live validation."
+```

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -62,3 +62,16 @@ Live test classes:
 
 - `tests/SwfocTrainer.Tests/Profiles/LiveTacticalToggleWorkflowTests.cs`
 - `tests/SwfocTrainer.Tests/Profiles/LiveHeroHelperWorkflowTests.cs`
+
+## Live evidence run pack
+
+Use the scripted run pack when preparing issue evidence for M1 closure:
+
+```powershell
+pwsh ./tools/run-live-validation.ps1 -Configuration Release -NoBuild
+```
+
+This writes TRX + launch context outputs and prefilled issue comment templates to
+`TestResults/`. See `docs/LIVE_VALIDATION_RUNBOOK.md`.
+If Python is unavailable in the running shell, the run pack still emits
+`launch-context-fixture.json` with a machine-readable failure status.

--- a/tools/run-live-validation.ps1
+++ b/tools/run-live-validation.ps1
@@ -1,0 +1,316 @@
+param(
+    [string]$Configuration = "Release",
+    [string]$ResultsDirectory = "TestResults",
+    [string]$ProfileRoot = "profiles/default",
+    [switch]$NoBuild = $true
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $repoRoot
+
+function Resolve-DotnetCommand {
+    $dotnet = Get-Command dotnet -ErrorAction SilentlyContinue
+    if ($null -ne $dotnet) {
+        return $dotnet.Source
+    }
+
+    $candidates = @(
+        (Join-Path $env:USERPROFILE ".dotnet\\dotnet.exe"),
+        (Join-Path $env:ProgramFiles "dotnet\\dotnet.exe")
+    )
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path -Path $candidate) {
+            return $candidate
+        }
+    }
+
+    throw "Could not resolve dotnet executable. Install .NET SDK or add dotnet to PATH."
+}
+
+function Resolve-PythonCommand {
+    $python = Get-Command python -ErrorAction SilentlyContinue
+    if ($null -ne $python) {
+        return @($python.Source)
+    }
+
+    $python3 = Get-Command python3 -ErrorAction SilentlyContinue
+    if ($null -ne $python3) {
+        return @($python3.Source)
+    }
+
+    $py = Get-Command py -ErrorAction SilentlyContinue
+    if ($null -ne $py) {
+        return @($py.Source, "-3")
+    }
+
+    $pathCandidates = @(
+        (Join-Path $env:SystemRoot "py.exe"),
+        (Join-Path $env:LocalAppData "Programs\\Python\\Python312\\python.exe"),
+        (Join-Path $env:LocalAppData "Programs\\Python\\Python311\\python.exe"),
+        (Join-Path $env:LocalAppData "Programs\\Python\\Python310\\python.exe"),
+        (Join-Path $env:ProgramFiles "Python312\\python.exe"),
+        (Join-Path $env:ProgramFiles "Python311\\python.exe"),
+        (Join-Path $env:ProgramFiles "Python310\\python.exe"),
+        (Join-Path ${env:ProgramFiles(x86)} "Python312\\python.exe"),
+        (Join-Path ${env:ProgramFiles(x86)} "Python311\\python.exe"),
+        (Join-Path ${env:ProgramFiles(x86)} "Python310\\python.exe")
+    )
+
+    foreach ($candidate in $pathCandidates) {
+        if ([string]::IsNullOrWhiteSpace($candidate)) {
+            continue
+        }
+
+        if (Test-Path -Path $candidate) {
+            if ($candidate.ToLowerInvariant().EndsWith("py.exe")) {
+                return @($candidate, "-3")
+            }
+
+            return @($candidate)
+        }
+    }
+
+    return $null
+}
+
+$dotnetExe = Resolve-DotnetCommand
+$resolvedPython = Resolve-PythonCommand
+if ($null -eq $resolvedPython) {
+    $pythonCmd = @()
+}
+elseif ($resolvedPython -is [System.Array]) {
+    $pythonCmd = @($resolvedPython | ForEach-Object { $_ })
+}
+else {
+    $pythonCmd = @($resolvedPython)
+}
+
+if (-not (Test-Path -Path $ResultsDirectory)) {
+    New-Item -ItemType Directory -Path $ResultsDirectory | Out-Null
+}
+
+function Invoke-LiveTest {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Filter,
+        [Parameter(Mandatory = $true)][string]$TrxName
+    )
+
+    Write-Host "=== Running $Name ==="
+
+    $args = @(
+        "test",
+        "tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj",
+        "-c", $Configuration,
+        "--filter", $Filter,
+        "--logger", "trx;LogFileName=$TrxName",
+        "--results-directory", $ResultsDirectory
+    )
+
+    if ($NoBuild) {
+        $args = $args[0..4] + "--no-build" + $args[5..($args.Count - 1)]
+    }
+
+    & $dotnetExe @args
+
+    return Join-Path $ResultsDirectory $TrxName
+}
+
+function Read-TrxSummary {
+    param([Parameter(Mandatory = $true)][string]$TrxPath)
+
+    if (-not (Test-Path -Path $TrxPath)) {
+        return [PSCustomObject]@{
+            Trx = $TrxPath
+            Outcome = "Missing"
+            Passed = 0
+            Failed = 0
+            Skipped = 0
+            Message = "TRX file not found"
+        }
+    }
+
+    [xml]$doc = Get-Content -Raw -Path $TrxPath
+    $ns = New-Object System.Xml.XmlNamespaceManager($doc.NameTable)
+    $ns.AddNamespace("t", "http://microsoft.com/schemas/VisualStudio/TeamTest/2010")
+
+    $counters = $doc.SelectSingleNode("//t:ResultSummary/t:Counters", $ns)
+    $unitResult = $doc.SelectSingleNode("//t:UnitTestResult", $ns)
+    $messageNode = $doc.SelectSingleNode("//t:UnitTestResult/t:Output/t:ErrorInfo/t:Message", $ns)
+
+    $passed = 0
+    $failed = 0
+    $skipped = 0
+    if ($null -ne $counters) {
+        $passed = [int]$counters.passed
+        $failed = [int]$counters.failed
+        $skipped = [int]$counters.notExecuted
+    }
+
+    if ($null -ne $unitResult -and $unitResult.outcome -eq "NotExecuted" -and $passed -eq 0 -and $failed -eq 0 -and $skipped -eq 0) {
+        $skipped = 1
+    }
+
+    $outcome = "Unknown"
+    if ($failed -gt 0) {
+        $outcome = "Failed"
+    }
+    elseif ($skipped -gt 0 -and $passed -eq 0) {
+        $outcome = "Skipped"
+    }
+    elseif ($passed -gt 0 -and $failed -eq 0) {
+        $outcome = "Passed"
+    }
+
+    return [PSCustomObject]@{
+        Trx = $TrxPath
+        Outcome = $outcome
+        Passed = $passed
+        Failed = $failed
+        Skipped = $skipped
+        Message = if ($null -ne $messageNode) { $messageNode.InnerText } else { "" }
+    }
+}
+
+$runTimestamp = Get-Date
+$iso = $runTimestamp.ToString("yyyy-MM-dd HH:mm:ss zzz")
+
+$trxTactical = Invoke-LiveTest -Name "Live Tactical Toggles" -Filter "FullyQualifiedName~LiveTacticalToggleWorkflowTests" -TrxName "live-tactical.trx"
+$trxHeroHelper = Invoke-LiveTest -Name "Live Hero Helper" -Filter "FullyQualifiedName~LiveHeroHelperWorkflowTests" -TrxName "live-hero-helper.trx"
+$trxRoeHealth = Invoke-LiveTest -Name "Live ROE Runtime Health" -Filter "FullyQualifiedName~LiveRoeRuntimeHealthTests" -TrxName "live-roe-health.trx"
+$trxCredits = Invoke-LiveTest -Name "Live Credits" -Filter "FullyQualifiedName~LiveCreditsTests" -TrxName "live-credits.trx"
+
+$launchContextJson = Join-Path $ResultsDirectory "launch-context-fixture.json"
+$pythonArgs = @(
+    "tools/detect-launch-context.py",
+    "--from-process-json", "tools/fixtures/launch_context_cases.json",
+    "--profile-root", $ProfileRoot,
+    "--pretty"
+)
+if ($pythonCmd.Count -eq 0 -or $null -eq $pythonCmd[0]) {
+    Write-Warning "Python was not found in this shell; skipping launch-context fixture generation."
+    [PSCustomObject]@{
+        status = "skipped"
+        reason = "python_not_found"
+        generatedAtUtc = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    } | ConvertTo-Json -Depth 4 | Set-Content -Path $launchContextJson
+}
+else {
+    try {
+        $pythonInvocationArgs = @()
+        if ($pythonCmd.Count -gt 1) {
+            $pythonInvocationArgs += $pythonCmd[1..($pythonCmd.Count - 1)]
+        }
+
+        $pythonInvocationArgs += $pythonArgs
+        $launchContextOutput = & $pythonCmd[0] @pythonInvocationArgs 2>&1
+        if (Get-Variable -Name LASTEXITCODE -Scope Global -ErrorAction SilentlyContinue) {
+            $exitCode = [int]$global:LASTEXITCODE
+        }
+        else {
+            $exitCode = 0
+        }
+        $outputText = ($launchContextOutput | Out-String).Trim()
+
+        if ($exitCode -ne 0) {
+            throw ("python exited with code {0}. output: {1}" -f $exitCode, $outputText)
+        }
+
+        if ([string]::IsNullOrWhiteSpace($outputText)) {
+            throw ("python produced no output. executable: {0}" -f $pythonCmd[0])
+        }
+
+        $launchContextOutput | Set-Content -Path $launchContextJson
+    }
+    catch {
+        Write-Warning ("Launch-context fixture generation failed: {0}" -f $_.Exception.Message)
+        [PSCustomObject]@{
+            status = "failed"
+            reason = "python_invocation_failed"
+            detail = $_.Exception.Message
+            generatedAtUtc = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+        } | ConvertTo-Json -Depth 4 | Set-Content -Path $launchContextJson
+    }
+}
+
+$summaries = @(
+    [PSCustomObject]@{ Name = "LiveTacticalToggleWorkflowTests"; Summary = Read-TrxSummary -TrxPath $trxTactical },
+    [PSCustomObject]@{ Name = "LiveHeroHelperWorkflowTests"; Summary = Read-TrxSummary -TrxPath $trxHeroHelper },
+    [PSCustomObject]@{ Name = "LiveRoeRuntimeHealthTests"; Summary = Read-TrxSummary -TrxPath $trxRoeHealth },
+    [PSCustomObject]@{ Name = "LiveCreditsTests"; Summary = Read-TrxSummary -TrxPath $trxCredits }
+)
+
+$summaryPath = Join-Path $ResultsDirectory "live-validation-summary.json"
+$summaries | ConvertTo-Json -Depth 6 | Set-Content -Path $summaryPath
+
+Write-Host ""
+Write-Host "=== Live Validation Summary ($iso) ==="
+foreach ($entry in $summaries) {
+    $s = $entry.Summary
+    Write-Host ("{0}: outcome={1} passed={2} failed={3} skipped={4} message='{5}'" -f $entry.Name, $s.Outcome, $s.Passed, $s.Failed, $s.Skipped, $s.Message)
+}
+Write-Host "launch-context fixture: $launchContextJson"
+Write-Host "summary json: $summaryPath"
+
+$template34 = Join-Path $ResultsDirectory "issue-34-evidence-template.md"
+$template19 = Join-Path $ResultsDirectory "issue-19-evidence-template.md"
+
+$lineTactical = $summaries[0].Summary
+$lineHero = $summaries[1].Summary
+$lineRoe = $summaries[2].Summary
+$lineCredits = $summaries[3].Summary
+
+@"
+Live validation evidence update ($iso)
+
+- Date/time: $iso
+- Profile id: <fill from live attach output>
+- Launch recommendation: <profileId/reasonCode/confidence from live attach output>
+- Runtime mode at attach: <fill>
+- Tactical toggle workflow: $($lineTactical.Outcome) (p=$($lineTactical.Passed), f=$($lineTactical.Failed), s=$($lineTactical.Skipped))
+  - detail: $($lineTactical.Message)
+- Hero helper workflow: $($lineHero.Outcome) (p=$($lineHero.Passed), f=$($lineHero.Failed), s=$($lineHero.Skipped))
+  - detail: $($lineHero.Message)
+- ROE runtime health: $($lineRoe.Outcome) (p=$($lineRoe.Passed), f=$($lineRoe.Failed), s=$($lineRoe.Skipped))
+  - detail: $($lineRoe.Message)
+- Credits live diagnostic: $($lineCredits.Outcome) (p=$($lineCredits.Passed), f=$($lineCredits.Failed), s=$($lineCredits.Skipped))
+  - detail: $($lineCredits.Message)
+- Diagnostics for degraded/unavailable actions: <fill>
+- Artifacts:
+  - $trxTactical
+  - $trxHeroHelper
+  - $trxRoeHealth
+  - $trxCredits
+  - $launchContextJson
+  - $summaryPath
+
+Status gate for closure:
+- [ ] At least one successful tactical toggle + revert in tactical mode
+- [ ] At least one helper workflow result captured per target profile (AOTR + ROE)
+"@ | Set-Content -Path $template34
+
+@"
+AOTR/ROE checklist evidence update ($iso)
+
+| Profile | Attach summary | Tactical toggle workflow | Hero helper workflow | Result |
+|---|---|---|---|---|
+| aotr_1397421866_swfoc | <fill pid/mode/reasonCode> | <pass/fail/skip + reason> | <pass/fail/skip + reason> | <overall> |
+| roe_3447786229_swfoc | <fill pid/mode/reasonCode> | <pass/fail/skip + reason> | <pass/fail/skip + reason> | <overall> |
+
+Current local run snapshot:
+- LiveTacticalToggleWorkflowTests: $($lineTactical.Outcome) ($($lineTactical.Message))
+- LiveHeroHelperWorkflowTests: $($lineHero.Outcome) ($($lineHero.Message))
+- LiveRoeRuntimeHealthTests: $($lineRoe.Outcome) ($($lineRoe.Message))
+- LiveCreditsTests: $($lineCredits.Outcome) ($($lineCredits.Message))
+
+Artifacts:
+- $summaryPath
+- $launchContextJson
+"@ | Set-Content -Path $template19
+
+Write-Host "issue template (34): $template34"
+Write-Host "issue template (19): $template19"


### PR DESCRIPTION
## Summary
- add `tools/run-live-validation.ps1` run pack for M1 live evidence capture
- add `docs/LIVE_VALIDATION_RUNBOOK.md` with exact commands and closure criteria
- update `docs/TEST_PLAN.md` and `TODO.md` with evidence workflow and blocker links
- harden run pack command resolution for `dotnet` and Python; emit machine-readable fallback status when fixture generation is unavailable

## Why
`#34` and `#19` require real live-session evidence (AOTR/ROE tactical/helper outcomes). This PR improves repeatability and issue hygiene while those sessions are pending.

## Validation
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File "tools/run-live-validation.ps1" -Configuration Release -NoBuild`
  - produced explicit skip diagnostics in the current environment (no live SWFOC process)
  - generated TRX + summary + issue templates under `TestResults/`

## Issue Links
- Refs #34
- Refs #19
- Refs #7
