### PR TITLE
feat: continue ghidra headless authoritative wave3

### DIFF
--- a/src/SwfocTrainer.Core/Models/SdkCapabilityModels.cs
+++ b/src/SwfocTrainer.Core/Models/SdkCapabilityModels.cs
@@ -68,6 +68,16 @@ public sealed record CapabilityOperationMap(
     IReadOnlyList<string> OptionalAnchors);
 
 /// <summary>
+/// Optional capability-probe metadata loaded from generated symbol packs/maps.
+/// </summary>
+public sealed record CapabilityAvailabilityHint(
+    string FeatureId,
+    bool Available,
+    string State,
+    string ReasonCode,
+    IReadOnlyList<string> RequiredAnchors);
+
+/// <summary>
 /// Persisted map keyed by binary fingerprint.
 /// </summary>
 public sealed record CapabilityMap(
@@ -75,7 +85,8 @@ public sealed record CapabilityMap(
     string FingerprintId,
     string? DefaultProfileId,
     DateTimeOffset GeneratedAtUtc,
-    IReadOnlyDictionary<string, CapabilityOperationMap> Operations);
+    IReadOnlyDictionary<string, CapabilityOperationMap> Operations,
+    IReadOnlyDictionary<string, CapabilityAvailabilityHint> CapabilityHints);
 
 /// <summary>
 /// Result of resolving an operation for a profile/fingerprint pair.

--- a/tests/SwfocTrainer.Tests/Runtime/CapabilityMapResolverTests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/CapabilityMapResolverTests.cs
@@ -199,4 +199,58 @@ public sealed class CapabilityMapResolverTests
             Directory.Delete(mapsRoot, recursive: true);
         }
     }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldFailClosed_WhenCapabilityHintDeclaresUnavailable()
+    {
+        var mapsRoot = Path.Combine(Path.GetTempPath(), $"swfoc-cap-map-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(mapsRoot);
+
+        try
+        {
+            var fingerprint = new BinaryFingerprint(
+                FingerprintId: "fp-ghidra-unavailable",
+                FileSha256: "abc123",
+                ModuleName: "StarWarsG.exe",
+                ProductVersion: "1.0",
+                FileVersion: "1.0.0.0",
+                TimestampUtc: DateTimeOffset.UtcNow,
+                ModuleList: Array.Empty<string>(),
+                SourcePath: "C:/games/StarWarsG.exe");
+
+            var mapJson = """
+            {
+              "schemaVersion": "1.0",
+              "fingerprintId": "fp-ghidra-unavailable",
+              "defaultProfileId": "base_swfoc",
+              "generatedAtUtc": "2026-02-24T00:00:00Z",
+              "capabilities": [
+                {
+                  "featureId": "freeze_timer",
+                  "available": false,
+                  "state": "Unavailable",
+                  "reasonCode": "CAPABILITY_REQUIRED_MISSING",
+                  "requiredAnchors": ["freeze_timer_patch"]
+                }
+              ]
+            }
+            """;
+            await File.WriteAllTextAsync(Path.Combine(mapsRoot, "fp-ghidra-unavailable.json"), mapJson);
+
+            var resolver = new CapabilityMapResolver(mapsRoot, NullLogger<CapabilityMapResolver>.Instance);
+            var result = await resolver.ResolveAsync(
+                fingerprint,
+                requestedProfileId: "base_swfoc",
+                operationId: "freeze_timer",
+                resolvedAnchors: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "freeze_timer_patch" });
+
+            result.State.Should().Be(SdkCapabilityStatus.Unavailable);
+            result.ReasonCode.Should().Be(CapabilityReasonCode.RequiredAnchorsMissing);
+            result.MissingAnchors.Should().ContainSingle().Which.Should().Be("freeze_timer_patch");
+        }
+        finally
+        {
+            Directory.Delete(mapsRoot, recursive: true);
+        }
+    }
 }

--- a/tools/ghidra/README.md
+++ b/tools/ghidra/README.md
@@ -14,6 +14,7 @@ This directory contains an automation-first reverse-engineering pipeline for SWF
 - `run-headless.ps1` (Windows)
 - `run-headless.sh` (Linux/WSL)
 - `emit-symbol-pack.py` (normalizes raw symbols into schema-backed outputs)
+- `check-determinism.py` (verifies anchor/capability determinism and emits classification-coded report)
 - `export_symbols.py` (Ghidra post-script executed by `analyzeHeadless`)
 - `check-determinism.py` (verifies deterministic symbol-pack output across reordered input symbols)
 
@@ -21,3 +22,4 @@ This directory contains an automation-first reverse-engineering pipeline for SWF
 
 - Set `GHIDRA_HOME` so scripts can find `support/analyzeHeadless`.
 - Optional: set `SWFOC_GHIDRA_SYMBOL_PACK_ROOT` at runtime to override symbol-pack lookup root.
+- `run-headless` now emits `determinism/determinism-report.json` and fails with classification code `GHIDRA_DETERMINISM_MISMATCH` when output diverges.

--- a/tools/ghidra/check-determinism.py
+++ b/tools/ghidra/check-determinism.py
@@ -13,6 +13,9 @@ import json
 import subprocess
 from pathlib import Path
 
+REASON_CODE_DETERMINISM_MISMATCH = "GHIDRA_DETERMINISM_MISMATCH"
+REASON_CODE_OK = "GHIDRA_DETERMINISM_PASS"
+
 
 def _run_emitter(
     emitter_path: Path,
@@ -109,13 +112,17 @@ def main() -> int:
 
     report = {
         "deterministic": matches,
+        "reasonCode": REASON_CODE_OK if matches else REASON_CODE_DETERMINISM_MISMATCH,
         "firstPackPath": str(first_pack).replace("\\", "/"),
         "secondPackPath": str(second_pack).replace("\\", "/"),
     }
     _write_report(output_dir / "determinism-report.json", report)
 
     if not matches:
-        raise SystemExit("ghidra symbol-pack determinism check failed")
+        raise SystemExit(
+            "ghidra symbol-pack determinism check failed "
+            f"(classification_code={REASON_CODE_DETERMINISM_MISMATCH})"
+        )
 
     print("ghidra symbol-pack determinism check passed")
     return 0

--- a/tools/ghidra/run-headless.ps1
+++ b/tools/ghidra/run-headless.ps1
@@ -33,6 +33,7 @@ $projectName = "swfoc-$AnalysisRunId"
 $rawSymbolsPath = Join-Path $OutputDir "raw-symbols.json"
 $symbolPackPath = Join-Path $OutputDir "symbol-pack.json"
 $summaryPath = Join-Path $OutputDir "analysis-summary.json"
+$determinismDir = Join-Path $OutputDir "determinism"
 
 & $analyzeHeadless `
     $projectDir `
@@ -50,7 +51,15 @@ python $emitScript `
     --output-pack $symbolPackPath `
     --output-summary $summaryPath
 
+$determinismScript = Join-Path $repoRoot "tools/ghidra/check-determinism.py"
+python $determinismScript `
+    --raw-symbols $rawSymbolsPath `
+    --binary-path $binaryFullPath `
+    --analysis-run-id-base $AnalysisRunId `
+    --output-dir $determinismDir
+
 Write-Output "ghidra headless analysis complete"
 Write-Output " - raw symbols: $rawSymbolsPath"
 Write-Output " - symbol pack: $symbolPackPath"
 Write-Output " - summary: $summaryPath"
+Write-Output " - determinism report: $(Join-Path $determinismDir 'determinism-report.json')"

--- a/tools/ghidra/run-headless.sh
+++ b/tools/ghidra/run-headless.sh
@@ -34,6 +34,7 @@ PROJECT_NAME="swfoc-${ANALYSIS_RUN_ID}"
 RAW_SYMBOLS_PATH="$OUTPUT_DIR/raw-symbols.json"
 SYMBOL_PACK_PATH="$OUTPUT_DIR/symbol-pack.json"
 SUMMARY_PATH="$OUTPUT_DIR/analysis-summary.json"
+DETERMINISM_DIR="$OUTPUT_DIR/determinism"
 
 "$ANALYZE_HEADLESS" "$PROJECT_DIR" "$PROJECT_NAME" \
   -import "$BINARY_PATH" \
@@ -48,7 +49,14 @@ python3 "$REPO_ROOT/tools/ghidra/emit-symbol-pack.py" \
   --output-pack "$SYMBOL_PACK_PATH" \
   --output-summary "$SUMMARY_PATH"
 
+python3 "$REPO_ROOT/tools/ghidra/check-determinism.py" \
+  --raw-symbols "$RAW_SYMBOLS_PATH" \
+  --binary-path "$BINARY_PATH" \
+  --analysis-run-id-base "$ANALYSIS_RUN_ID" \
+  --output-dir "$DETERMINISM_DIR"
+
 echo "ghidra headless analysis complete"
 echo " - raw symbols: $RAW_SYMBOLS_PATH"
 echo " - symbol pack: $SYMBOL_PACK_PATH"
 echo " - summary: $SUMMARY_PATH"
+echo " - determinism report: $DETERMINISM_DIR/determinism-report.json"


### PR DESCRIPTION
## Summary
- harden headless Ghidra pipeline determinism reporting with explicit classification codes
- run determinism verification as part of both `run-headless.sh` and `run-headless.ps1`
- extend capability map resolver to consume capability-hint metadata (`available/state/reasonCode`) and fail closed when declared unavailable
- add resolver test coverage for capability-hint fail-closed behavior

## Validation
- `python3 tools/ghidra/check-determinism.py --raw-symbols tools/fixtures/ghidra_raw_symbols_sample.json --binary-path README.md --analysis-run-id-base local-wave3 --output-dir TestResults/ghidra-local-determinism`
- `dotnet restore SwfocTrainer.sln`
- `dotnet build SwfocTrainer.sln -c Release --no-restore`
- `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --no-build --filter "FullyQualifiedName!~SwfocTrainer.Tests.Profiles.Live&FullyQualifiedName!~RuntimeAttachSmokeTests"`

## Runtime Evidence
repro bundle json: justified skip (headless ghidra/runtime contract batch; no live runtime behavior change)
classification: justified skip

## Risk
- risk:medium (runtime capability gating semantics changed)
