### PR TITLE
fix: harden profile archive extraction and clear sonar hotspot

### DIFF
--- a/tests/SwfocTrainer.Tests/Profiles/ProfileUpdateServiceTransactionalTests.cs
+++ b/tests/SwfocTrainer.Tests/Profiles/ProfileUpdateServiceTransactionalTests.cs
@@ -95,6 +95,146 @@ public sealed class ProfileUpdateServiceTransactionalTests
         }
     }
 
+    [Fact]
+    public async Task InstallProfileTransactionalAsync_ShouldFailWhenArchiveContainsDriveQualifiedPath()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"swfoc-profile-update-{Guid.NewGuid():N}");
+        var profilesRoot = Path.Combine(tempRoot, "default");
+        var profilesDir = Path.Combine(profilesRoot, "profiles");
+        var cacheDir = Path.Combine(tempRoot, "cache");
+        Directory.CreateDirectory(profilesDir);
+        Directory.CreateDirectory(cacheDir);
+
+        try
+        {
+            var profileId = "base_swfoc";
+            var downloadedProfileJson = "{\"id\":\"base_swfoc\",\"displayName\":\"new\",\"inherits\":null,\"exeTarget\":\"Swfoc\",\"steamWorkshopId\":null,\"signatureSets\":[{\"name\":\"x\",\"gameBuild\":\"x\",\"signatures\":[]}],\"fallbackOffsets\":{},\"actions\":{},\"featureFlags\":{},\"catalogSources\":[],\"saveSchemaId\":\"base_swfoc_steam_v1\",\"helperModHooks\":[]}";
+            var zipBytes = BuildZipWithEntries(new Dictionary<string, string>
+            {
+                [$"profiles/{profileId}.json"] = downloadedProfileJson,
+                ["C:evil.txt"] = "bad"
+            });
+            var sha = ComputeSha256(zipBytes);
+
+            var manifestJson = JsonSerializer.Serialize(new
+            {
+                version = "1.0.0",
+                publishedAt = "2026-01-01T00:00:00Z",
+                profiles = new[]
+                {
+                    new
+                    {
+                        id = profileId,
+                        version = "1.2.3",
+                        sha256 = sha,
+                        downloadUrl = $"https://example.invalid/{profileId}.zip",
+                        minAppVersion = "1.0.0",
+                        description = "test"
+                    }
+                }
+            });
+
+            var handler = new StubHttpMessageHandler(new Dictionary<string, (string ContentType, byte[] Body)>
+            {
+                ["https://example.invalid/manifest.json"] = ("application/json", Encoding.UTF8.GetBytes(manifestJson)),
+                [$"https://example.invalid/{profileId}.zip"] = ("application/zip", zipBytes)
+            });
+            var client = new HttpClient(handler);
+
+            var options = new ProfileRepositoryOptions
+            {
+                ProfilesRootPath = profilesRoot,
+                ManifestFileName = "manifest.json",
+                DownloadCachePath = cacheDir,
+                RemoteManifestUrl = "https://example.invalid/manifest.json"
+            };
+
+            var service = new GitHubProfileUpdateService(client, options, new StubProfileRepository());
+            var result = await service.InstallProfileTransactionalAsync(profileId);
+
+            result.Succeeded.Should().BeFalse();
+            result.ReasonCode.Should().Be("extract_failed");
+            result.Message.Should().Contain("drive-qualified");
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task InstallProfileTransactionalAsync_ShouldFailWhenArchiveContainsTraversalPath()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"swfoc-profile-update-{Guid.NewGuid():N}");
+        var profilesRoot = Path.Combine(tempRoot, "default");
+        var profilesDir = Path.Combine(profilesRoot, "profiles");
+        var cacheDir = Path.Combine(tempRoot, "cache");
+        Directory.CreateDirectory(profilesDir);
+        Directory.CreateDirectory(cacheDir);
+
+        try
+        {
+            var profileId = "base_swfoc";
+            var downloadedProfileJson = "{\"id\":\"base_swfoc\",\"displayName\":\"new\",\"inherits\":null,\"exeTarget\":\"Swfoc\",\"steamWorkshopId\":null,\"signatureSets\":[{\"name\":\"x\",\"gameBuild\":\"x\",\"signatures\":[]}],\"fallbackOffsets\":{},\"actions\":{},\"featureFlags\":{},\"catalogSources\":[],\"saveSchemaId\":\"base_swfoc_steam_v1\",\"helperModHooks\":[]}";
+            var zipBytes = BuildZipWithEntries(new Dictionary<string, string>
+            {
+                [$"profiles/{profileId}.json"] = downloadedProfileJson,
+                ["../escape.txt"] = "bad"
+            });
+            var sha = ComputeSha256(zipBytes);
+
+            var manifestJson = JsonSerializer.Serialize(new
+            {
+                version = "1.0.0",
+                publishedAt = "2026-01-01T00:00:00Z",
+                profiles = new[]
+                {
+                    new
+                    {
+                        id = profileId,
+                        version = "1.2.3",
+                        sha256 = sha,
+                        downloadUrl = $"https://example.invalid/{profileId}.zip",
+                        minAppVersion = "1.0.0",
+                        description = "test"
+                    }
+                }
+            });
+
+            var handler = new StubHttpMessageHandler(new Dictionary<string, (string ContentType, byte[] Body)>
+            {
+                ["https://example.invalid/manifest.json"] = ("application/json", Encoding.UTF8.GetBytes(manifestJson)),
+                [$"https://example.invalid/{profileId}.zip"] = ("application/zip", zipBytes)
+            });
+            var client = new HttpClient(handler);
+
+            var options = new ProfileRepositoryOptions
+            {
+                ProfilesRootPath = profilesRoot,
+                ManifestFileName = "manifest.json",
+                DownloadCachePath = cacheDir,
+                RemoteManifestUrl = "https://example.invalid/manifest.json"
+            };
+
+            var service = new GitHubProfileUpdateService(client, options, new StubProfileRepository());
+            var result = await service.InstallProfileTransactionalAsync(profileId);
+
+            result.Succeeded.Should().BeFalse();
+            result.ReasonCode.Should().Be("extract_failed");
+            result.Message.Should().Contain("escapes extraction root");
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
     private static byte[] BuildZipWithProfile(string profileId, string profileJson)
     {
         using var memory = new MemoryStream();
@@ -104,6 +244,23 @@ public sealed class ProfileUpdateServiceTransactionalTests
             using var stream = entry.Open();
             using var writer = new StreamWriter(stream, Encoding.UTF8, leaveOpen: false);
             writer.Write(profileJson);
+        }
+
+        return memory.ToArray();
+    }
+
+    private static byte[] BuildZipWithEntries(IReadOnlyDictionary<string, string> entries)
+    {
+        using var memory = new MemoryStream();
+        using (var zip = new ZipArchive(memory, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var entrySpec in entries)
+            {
+                var entry = zip.CreateEntry(entrySpec.Key);
+                using var stream = entry.Open();
+                using var writer = new StreamWriter(stream, Encoding.UTF8, leaveOpen: false);
+                writer.Write(entrySpec.Value);
+            }
         }
 
         return memory.ToArray();


### PR DESCRIPTION
## Summary
- harden archive extraction in profile updater to eliminate hotspot-triggering extraction path while preserving fail-closed behavior
- reject drive-qualified archive entries and keep root-escape prevention
- add transactional tests for drive-qualified and traversal zip entries

## Evidence
justified skip: no runtime behavior change; deterministic verification only
repro bundle json: justified skip (non-live, archive extraction hardening)

## Verification
- dotnet restore SwfocTrainer.sln
- dotnet build SwfocTrainer.sln -c Release --no-restore
- dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --no-build --filter "FullyQualifiedName!~SwfocTrainer.Tests.Profiles.Live&FullyQualifiedName!~RuntimeAttachSmokeTests"
- dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --filter "FullyQualifiedName~ProfileUpdateServiceTransactionalTests"
- powershell.exe -NoProfile -ExecutionPolicy Bypass -File tools/validate-policy-contracts.ps1

## Risk
risk:low
Rollback: revert commit 3263c1a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced archive extraction with improved path validation, normalization, and boundary enforcement. Archive entries are now validated to prevent extraction outside the target directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->