### PR TITLE
Route FoC quick actions through managed backends

### DIFF
--- a/profiles/default/profiles/base_swfoc.json
+++ b/profiles/default/profiles/base_swfoc.json
@@ -83,19 +83,19 @@
       "id": "set_credits",
       "category": "Economy",
       "mode": "Unknown",
-      "executionKind": "Sdk",
+      "executionKind": "Memory",
       "payloadSchema": {
         "required": ["symbol", "intValue"]
       },
       "verifyReadback": true,
       "cooldownMs": 250,
-      "description": "Set player credits via extender path (one-shot by default; optional lockCredits/forcePatchHook alias)"
+      "description": "Set player credits via managed runtime path (one-shot by default; optional lockCredits/forcePatchHook alias)"
     },
     "freeze_timer": {
       "id": "freeze_timer",
       "category": "Global",
       "mode": "Unknown",
-      "executionKind": "Sdk",
+      "executionKind": "Memory",
       "payloadSchema": {
         "required": ["symbol", "boolValue"]
       },
@@ -107,7 +107,7 @@
       "id": "toggle_fog_reveal",
       "category": "Global",
       "mode": "Unknown",
-      "executionKind": "Sdk",
+      "executionKind": "Memory",
       "payloadSchema": {
         "required": ["symbol", "boolValue"]
       },
@@ -119,7 +119,7 @@
       "id": "toggle_ai",
       "category": "Global",
       "mode": "Unknown",
-      "executionKind": "Sdk",
+      "executionKind": "Memory",
       "payloadSchema": {
         "required": ["symbol", "boolValue"]
       },
@@ -287,7 +287,7 @@
       "id": "set_unit_cap",
       "category": "Global",
       "mode": "Unknown",
-      "executionKind": "Sdk",
+      "executionKind": "CodePatch",
       "payloadSchema": {
         "required": ["intValue"]
       },
@@ -299,7 +299,7 @@
       "id": "toggle_instant_build_patch",
       "category": "Global",
       "mode": "Unknown",
-      "executionKind": "Sdk",
+      "executionKind": "CodePatch",
       "payloadSchema": {
         "required": ["enable"]
       },

--- a/src/SwfocTrainer.Runtime/Services/BackendRouter.cs
+++ b/src/SwfocTrainer.Runtime/Services/BackendRouter.cs
@@ -59,7 +59,7 @@ public sealed class BackendRouter : IBackendRouter
         ProcessMetadata process,
         CapabilityReport capabilityReport)
     {
-        var isPromotedExtenderAction = IsPromotedExtenderAction(request.Action.Id, profile, process);
+        var isPromotedExtenderAction = IsPromotedExtenderAction(request.Action.Id, request.Action.ExecutionKind, profile, process);
         var defaultBackend = MapDefaultBackend(request.Action.ExecutionKind, isPromotedExtenderAction);
         var preferredBackend = ResolvePreferredBackend(profile.BackendPreference, defaultBackend, isPromotedExtenderAction);
         var isMutating = IsMutating(request.Action.Id);
@@ -395,10 +395,12 @@ public sealed class BackendRouter : IBackendRouter
 
     private static bool IsPromotedExtenderAction(
         string actionId,
+        ExecutionKind executionKind,
         TrainerProfile profile,
         ProcessMetadata process)
     {
-        return IsFoCContext(profile, process) &&
+        return executionKind == ExecutionKind.Sdk &&
+               IsFoCContext(profile, process) &&
                !string.IsNullOrWhiteSpace(actionId) &&
                PromotedExtenderActionIds.Contains(actionId);
     }

--- a/src/SwfocTrainer.Runtime/Services/RuntimeAdapter.cs
+++ b/src/SwfocTrainer.Runtime/Services/RuntimeAdapter.cs
@@ -1347,6 +1347,13 @@ public sealed class RuntimeAdapter : IRuntimeAdapter
         return !string.IsNullOrWhiteSpace(value);
     }
 
+    private static bool IsPromotedExtenderAction(string actionId, ExecutionKind executionKind)
+    {
+        return executionKind == ExecutionKind.Sdk &&
+               !string.IsNullOrWhiteSpace(actionId) &&
+               PromotedExtenderActionIds.Contains(actionId);
+    }
+
     private static bool IsPromotedExtenderAction(string actionId)
     {
         return !string.IsNullOrWhiteSpace(actionId) &&
@@ -1541,7 +1548,7 @@ public sealed class RuntimeAdapter : IRuntimeAdapter
     {
         return !routeDecision.Allowed &&
                routeDecision.Backend == ExecutionBackendKind.Extender &&
-               IsPromotedExtenderAction(request.Action.Id) &&
+               IsPromotedExtenderAction(request.Action.Id, request.Action.ExecutionKind) &&
                IsMutatingActionId(request.Action.Id);
     }
 

--- a/tests/SwfocTrainer.Tests/Profiles/LivePromotedActionMatrixTests.cs
+++ b/tests/SwfocTrainer.Tests/Profiles/LivePromotedActionMatrixTests.cs
@@ -67,7 +67,7 @@ public sealed class LivePromotedActionMatrixTests
     public LivePromotedActionMatrixTests(ITestOutputHelper output) => _output = output;
 
     [SkippableFact]
-    public async Task Promoted_Actions_Should_Route_Via_Extender_Without_Hybrid_Fallback()
+    public async Task Promoted_Actions_Should_Route_Via_Managed_Backends_Without_Hybrid_Fallback()
     {
         var matrixEntries = new List<ActionStatusEntry>(TargetProfiles.Length * PromotedActions.Length);
         try
@@ -262,19 +262,17 @@ public sealed class LivePromotedActionMatrixTests
     {
         result.Succeeded.Should().BeTrue(
             $"promoted action '{actionId}' should execute successfully for profile '{profileId}'. message={result.Message}");
-        backendRoute.Should().Be(
-            ExecutionBackendKind.Extender.ToString(),
-            because: $"promoted action '{actionId}' should route via extender backend for profile '{profileId}'.");
+        backendRoute.Should().BeOneOf(
+            ExecutionBackendKind.Memory.ToString(),
+            ExecutionBackendKind.Helper.ToString(),
+            because: $"promoted action '{actionId}' should route via managed backend for profile '{profileId}'.");
         routeReasonCode.Should().Be(
             RuntimeReasonCode.CAPABILITY_PROBE_PASS.ToString(),
             because: $"promoted action '{actionId}' should pass route capability gate for profile '{profileId}'.");
-        capabilityProbeReasonCode.Should().Be(
-            RuntimeReasonCode.CAPABILITY_PROBE_PASS.ToString(),
-            because: $"promoted action '{actionId}' should report capability probe pass for profile '{profileId}'.");
         hybridExecution.HasValue.Should().BeTrue(
             because: $"promoted action '{actionId}' should emit hybrid execution diagnostics for profile '{profileId}'.");
         hybridExecution.Should().BeFalse(
-            because: $"promoted action '{actionId}' should execute as native-authoritative extender flow for profile '{profileId}'.");
+            because: $"promoted action '{actionId}' should execute through managed runtime flow for profile '{profileId}'.");
         hasFallbackMarker.Should().BeFalse(
             because: $"promoted action '{actionId}' should not include fallback markers for profile '{profileId}'.");
     }

--- a/tests/SwfocTrainer.Tests/Profiles/ProfileActionCatalogTests.cs
+++ b/tests/SwfocTrainer.Tests/Profiles/ProfileActionCatalogTests.cs
@@ -36,7 +36,7 @@ public sealed class ProfileActionCatalogTests
     }
 
     [Fact]
-    public async Task BaseSwfoc_Should_Route_Promoted_Actions_Via_Sdk()
+    public async Task BaseSwfoc_Should_Route_Quick_Actions_Via_Managed_Runtime()
     {
         var root = TestPaths.FindRepoRoot();
         var options = new ProfileRepositoryOptions
@@ -53,17 +53,17 @@ public sealed class ProfileActionCatalogTests
         profile.Actions.Should().ContainKey("set_unit_cap");
         profile.Actions.Should().ContainKey("toggle_instant_build_patch");
 
-        profile.Actions["freeze_timer"].ExecutionKind.Should().Be(ExecutionKind.Sdk);
-        profile.Actions["toggle_fog_reveal"].ExecutionKind.Should().Be(ExecutionKind.Sdk);
-        profile.Actions["toggle_ai"].ExecutionKind.Should().Be(ExecutionKind.Sdk);
+        profile.Actions["freeze_timer"].ExecutionKind.Should().Be(ExecutionKind.Memory);
+        profile.Actions["toggle_fog_reveal"].ExecutionKind.Should().Be(ExecutionKind.Memory);
+        profile.Actions["toggle_ai"].ExecutionKind.Should().Be(ExecutionKind.Memory);
 
         var cap = profile.Actions["set_unit_cap"];
-        cap.ExecutionKind.Should().Be(ExecutionKind.Sdk);
+        cap.ExecutionKind.Should().Be(ExecutionKind.CodePatch);
         var capRequired = cap.PayloadSchema["required"]!.AsArray().Select(x => x!.GetValue<string>()).ToList();
         capRequired.Should().Contain("intValue");
 
         var instantBuild = profile.Actions["toggle_instant_build_patch"];
-        instantBuild.ExecutionKind.Should().Be(ExecutionKind.Sdk);
+        instantBuild.ExecutionKind.Should().Be(ExecutionKind.CodePatch);
         var instantRequired = instantBuild.PayloadSchema["required"]!.AsArray().Select(x => x!.GetValue<string>()).ToList();
         instantRequired.Should().Contain("enable");
     }
@@ -88,7 +88,7 @@ public sealed class ProfileActionCatalogTests
     }
 
     [Fact]
-    public async Task RoeProfile_Should_Inherit_Promoted_Sdk_Actions_From_Base()
+    public async Task RoeProfile_Should_Inherit_Managed_Quick_Actions_From_Base()
     {
         var root = TestPaths.FindRepoRoot();
         var options = new ProfileRepositoryOptions
@@ -102,15 +102,15 @@ public sealed class ProfileActionCatalogTests
         // ROE inherits from AOTR which inherits from base_swfoc
         profile.Actions.Should().ContainKey("freeze_symbol");
         profile.Actions.Should().ContainKey("unfreeze_symbol");
-        profile.Actions["freeze_timer"].ExecutionKind.Should().Be(ExecutionKind.Sdk);
-        profile.Actions["toggle_fog_reveal"].ExecutionKind.Should().Be(ExecutionKind.Sdk);
-        profile.Actions["toggle_ai"].ExecutionKind.Should().Be(ExecutionKind.Sdk);
+        profile.Actions["freeze_timer"].ExecutionKind.Should().Be(ExecutionKind.Memory);
+        profile.Actions["toggle_fog_reveal"].ExecutionKind.Should().Be(ExecutionKind.Memory);
+        profile.Actions["toggle_ai"].ExecutionKind.Should().Be(ExecutionKind.Memory);
 
         // Also verify promoted former CodePatch actions survive inheritance as SDK-routed actions.
         profile.Actions.Should().ContainKey("set_unit_cap");
-        profile.Actions["set_unit_cap"].ExecutionKind.Should().Be(ExecutionKind.Sdk);
+        profile.Actions["set_unit_cap"].ExecutionKind.Should().Be(ExecutionKind.CodePatch);
         profile.Actions.Should().ContainKey("toggle_instant_build_patch");
-        profile.Actions["toggle_instant_build_patch"].ExecutionKind.Should().Be(ExecutionKind.Sdk);
+        profile.Actions["toggle_instant_build_patch"].ExecutionKind.Should().Be(ExecutionKind.CodePatch);
     }
 
     [Fact]
@@ -134,7 +134,7 @@ public sealed class ProfileActionCatalogTests
     }
 
     [Fact]
-    public async Task SwfocProfiles_Should_Route_SetCredits_Via_Sdk()
+    public async Task SwfocProfiles_Should_Route_SetCredits_Via_Memory()
     {
         var root = TestPaths.FindRepoRoot();
         var options = new ProfileRepositoryOptions
@@ -148,7 +148,7 @@ public sealed class ProfileActionCatalogTests
         foreach (var pid in swfocProfiles)
         {
             var profile = await repo.ResolveInheritedProfileAsync(pid);
-            profile.Actions["set_credits"].ExecutionKind.Should().Be(ExecutionKind.Sdk,
+            profile.Actions["set_credits"].ExecutionKind.Should().Be(ExecutionKind.Memory,
                 because: $"profile '{pid}' should enforce extender-routed credits writes");
         }
     }


### PR DESCRIPTION
## Summary
- Re-routed `base_swfoc` quick actions away from SDK/extender placeholders to currently implemented managed paths:
  - `set_credits`, `freeze_timer`, `toggle_fog_reveal`, `toggle_ai` -> `Memory`
  - `set_unit_cap`, `toggle_instant_build_patch` -> `CodePatch`
- Updated backend promotion logic so FoC promoted-extender gating only applies when an action is explicitly `executionKind: Sdk`.
- Updated runtime override eligibility to respect the same execution-kind gate.
- Updated tests that asserted extender routing/execution kinds to reflect managed routing behavior.

## Why
Extender plugins are still no-op for these actions, so SDK routing could report success without in-game mutation. This change aligns routing with implemented mutation paths.

## Affected profile IDs
- `base_swfoc` (direct action catalog changes)
- `aotr_1397421866_swfoc` (inherits from base)
- `roe_3447786229_swfoc` (inherits from base/aotr)

## Diagnostics / reason-code impact
- Former FoC promoted actions configured as `Memory`/`CodePatch` no longer force extender capability gates.
- Expected routing reason code for these actions under auto preference is now `CAPABILITY_PROBE_PASS` with `backendRoute=Memory`.
- `promotedExtenderAction=false` for these actions unless execution kind is explicitly `Sdk`.

## Risk
- `risk:low`
- Rollback: revert this commit to restore SDK/extender routing for the six FoC quick actions.

## Validation
- Attempted deterministic tests:
  - `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --filter "FullyQualifiedName~BackendRouterTests|FullyQualifiedName~ProfileActionCatalogTests|FullyQualifiedName~RuntimeAdapterHybridManagedActionTests"`
- Environment limitation: `dotnet` CLI is not installed (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a257e551a88332abc8b6f18e3870e3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated execution routing for several actions to use managed runtime backends instead of SDK execution paths, affecting set_credits, freeze_timer, toggle_fog_reveal, toggle_ai, set_unit_cap, and toggle_instant_build_patch.

* **Tests**
  * Updated test assertions and naming to reflect new backend routing expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->