### PR TITLE
Promote extender routing only for SDK execution semantics

### DIFF
--- a/src/SwfocTrainer.Runtime/Services/BackendRouter.cs
+++ b/src/SwfocTrainer.Runtime/Services/BackendRouter.cs
@@ -59,7 +59,7 @@ public sealed class BackendRouter : IBackendRouter
         ProcessMetadata process,
         CapabilityReport capabilityReport)
     {
-        var isPromotedExtenderAction = IsPromotedExtenderAction(request.Action.Id, profile, process);
+        var isPromotedExtenderAction = IsPromotedExtenderAction(request.Action.Id, request.Action.ExecutionKind, profile, process);
         var defaultBackend = MapDefaultBackend(request.Action.ExecutionKind, isPromotedExtenderAction);
         var preferredBackend = ResolvePreferredBackend(profile.BackendPreference, defaultBackend, isPromotedExtenderAction);
         var isMutating = IsMutating(request.Action.Id);
@@ -395,9 +395,15 @@ public sealed class BackendRouter : IBackendRouter
 
     private static bool IsPromotedExtenderAction(
         string actionId,
+        ExecutionKind executionKind,
         TrainerProfile profile,
         ProcessMetadata process)
     {
+        if (executionKind != ExecutionKind.Sdk)
+        {
+            return false;
+        }
+
         return IsFoCContext(profile, process) &&
                !string.IsNullOrWhiteSpace(actionId) &&
                PromotedExtenderActionIds.Contains(actionId);

--- a/src/SwfocTrainer.Runtime/Services/RuntimeAdapter.cs
+++ b/src/SwfocTrainer.Runtime/Services/RuntimeAdapter.cs
@@ -1347,8 +1347,13 @@ public sealed class RuntimeAdapter : IRuntimeAdapter
         return !string.IsNullOrWhiteSpace(value);
     }
 
-    private static bool IsPromotedExtenderAction(string actionId)
+    private static bool IsPromotedExtenderAction(string actionId, ExecutionKind executionKind)
     {
+        if (executionKind != ExecutionKind.Sdk)
+        {
+            return false;
+        }
+
         return !string.IsNullOrWhiteSpace(actionId) &&
                PromotedExtenderActionIds.Contains(actionId);
     }
@@ -1541,7 +1546,7 @@ public sealed class RuntimeAdapter : IRuntimeAdapter
     {
         return !routeDecision.Allowed &&
                routeDecision.Backend == ExecutionBackendKind.Extender &&
-               IsPromotedExtenderAction(request.Action.Id) &&
+               IsPromotedExtenderAction(request.Action.Id, request.Action.ExecutionKind) &&
                IsMutatingActionId(request.Action.Id);
     }
 
@@ -1630,7 +1635,7 @@ public sealed class RuntimeAdapter : IRuntimeAdapter
         var anchors = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         MergeAnchorsFromRequestContext(request, anchors);
         TryAddPayloadSymbolAnchor(request.Payload, anchors);
-        AddPromotedActionAnchors(request.Action.Id, anchors);
+        AddPromotedActionAnchors(request.Action.Id, request.Action.ExecutionKind, anchors);
         AddActiveHookAnchors(anchors);
         return anchors;
     }
@@ -1657,9 +1662,9 @@ public sealed class RuntimeAdapter : IRuntimeAdapter
         }
     }
 
-    private void AddPromotedActionAnchors(string actionId, IDictionary<string, string> anchors)
+    private void AddPromotedActionAnchors(string actionId, ExecutionKind executionKind, IDictionary<string, string> anchors)
     {
-        if (!IsPromotedExtenderAction(actionId))
+        if (!IsPromotedExtenderAction(actionId, executionKind))
         {
             return;
         }

--- a/tests/SwfocTrainer.Tests/Runtime/BackendRouterTests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/BackendRouterTests.cs
@@ -9,11 +9,11 @@ namespace SwfocTrainer.Tests.Runtime;
 public sealed class BackendRouterTests
 {
     [Theory]
-    [InlineData("freeze_timer", ExecutionKind.Memory)]
-    [InlineData("toggle_fog_reveal", ExecutionKind.Memory)]
-    [InlineData("toggle_ai", ExecutionKind.Memory)]
-    [InlineData("set_unit_cap", ExecutionKind.CodePatch)]
-    [InlineData("toggle_instant_build_patch", ExecutionKind.CodePatch)]
+    [InlineData("freeze_timer", ExecutionKind.Sdk)]
+    [InlineData("toggle_fog_reveal", ExecutionKind.Sdk)]
+    [InlineData("toggle_ai", ExecutionKind.Sdk)]
+    [InlineData("set_unit_cap", ExecutionKind.Sdk)]
+    [InlineData("toggle_instant_build_patch", ExecutionKind.Sdk)]
     public void Resolve_ShouldPromoteHybridActions_ToExtender_WhenCapabilityIsAvailable(
         string actionId,
         ExecutionKind executionKind)
@@ -61,11 +61,11 @@ public sealed class BackendRouterTests
     }
 
     [Theory]
-    [InlineData("freeze_timer", ExecutionKind.Memory)]
-    [InlineData("toggle_fog_reveal", ExecutionKind.Memory)]
-    [InlineData("toggle_ai", ExecutionKind.Memory)]
-    [InlineData("set_unit_cap", ExecutionKind.CodePatch)]
-    [InlineData("toggle_instant_build_patch", ExecutionKind.CodePatch)]
+    [InlineData("freeze_timer", ExecutionKind.Sdk)]
+    [InlineData("toggle_fog_reveal", ExecutionKind.Sdk)]
+    [InlineData("toggle_ai", ExecutionKind.Sdk)]
+    [InlineData("set_unit_cap", ExecutionKind.Sdk)]
+    [InlineData("toggle_instant_build_patch", ExecutionKind.Sdk)]
     public void Resolve_ShouldBlockHybridActions_WhenCapabilityIsMissing(
         string actionId,
         ExecutionKind executionKind)
@@ -89,11 +89,11 @@ public sealed class BackendRouterTests
     }
 
     [Theory]
-    [InlineData("freeze_timer", ExecutionKind.Memory)]
-    [InlineData("toggle_fog_reveal", ExecutionKind.Memory)]
-    [InlineData("toggle_ai", ExecutionKind.Memory)]
-    [InlineData("set_unit_cap", ExecutionKind.CodePatch)]
-    [InlineData("toggle_instant_build_patch", ExecutionKind.CodePatch)]
+    [InlineData("freeze_timer", ExecutionKind.Sdk)]
+    [InlineData("toggle_fog_reveal", ExecutionKind.Sdk)]
+    [InlineData("toggle_ai", ExecutionKind.Sdk)]
+    [InlineData("set_unit_cap", ExecutionKind.Sdk)]
+    [InlineData("toggle_instant_build_patch", ExecutionKind.Sdk)]
     public void Resolve_ShouldFailClosedForPromotedActions_WhenCapabilityIsUnverified(
         string actionId,
         ExecutionKind executionKind)
@@ -237,6 +237,23 @@ public sealed class BackendRouterTests
 
         decision.Allowed.Should().BeTrue();
         decision.Backend.Should().Be(ExecutionBackendKind.Memory);
+    }
+
+    [Fact]
+    public void Resolve_ShouldPreserveFoCMemoryIntent_ForPromotedActionIdWhenExecutionIsNotSdk()
+    {
+        var router = new BackendRouter();
+        var request = BuildRequest("freeze_timer", ExecutionKind.Memory);
+        var profile = BuildProfile(backendPreference: "auto");
+        var process = BuildProcess();
+        var report = CapabilityReport.Unknown(profile.Id, RuntimeReasonCode.CAPABILITY_UNKNOWN);
+
+        var decision = router.Resolve(request, profile, process, report);
+
+        decision.Allowed.Should().BeTrue();
+        decision.Backend.Should().Be(ExecutionBackendKind.Memory);
+        decision.Diagnostics.Should().ContainKey("promotedExtenderAction");
+        decision.Diagnostics!["promotedExtenderAction"].Should().Be(false);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Prevent promoted action IDs from forcing Extender routing when the action's `ExecutionKind` is non-SDK, so promotion is driven by execution semantics rather than static ID membership.
- Preserve legacy execution-kind intent (Memory/CodePatch -> memory path) in FoC contexts while retaining fail-closed safety for true SDK mutating operations.
- Ensure runtime diagnostics and anchor injection reflect the execution-kind-aware promotion policy and provide reason-code level signals for gating decisions.

### Description
- Changed `BackendRouter.CreateRouteResolutionState` to call `IsPromotedExtenderAction(actionId, executionKind, profile, process)` so promotion requires `ExecutionKind.Sdk` in FoC contexts. (`src/SwfocTrainer.Runtime/Services/BackendRouter.cs`)
- Updated `RuntimeAdapter` helpers to be execution-kind-aware by adding an `ExecutionKind` parameter to `IsPromotedExtenderAction`, and used that for expert-override eligibility and promoted-anchor injection. (`src/SwfocTrainer.Runtime/Services/RuntimeAdapter.cs`)
- Left default backend mapping and auto-fallback logic intact so non-SDK execution kinds continue to map to memory/helper/save backends as before. (`MapDefaultBackend`/`ResolveAutoFallbackBackend` unchanged semantically.)
- Updated unit tests in `tests/SwfocTrainer.Tests/Runtime/BackendRouterTests.cs` to assert promotion/fail-closed behavior for SDK execution and added a regression test that a FoC promoted ID executed with `ExecutionKind.Memory` preserves memory routing and emits `promotedExtenderAction=false`.
- Diagnostics/Reason-codes observed by routing remain the same keys; SDK-promoted flows continue to emit reason codes such as `CAPABILITY_PROBE_PASS`, `CAPABILITY_REQUIRED_MISSING`, `SAFETY_FAIL_CLOSED`, `CAPABILITY_BACKEND_UNAVAILABLE`, and `SAFETY_MUTATION_BLOCKED` as appropriate.

### Testing
- Unit tests modified: `tests/SwfocTrainer.Tests/Runtime/BackendRouterTests.cs` (updated promotion cases to `ExecutionKind.Sdk` and added `Resolve_ShouldPreserveFoCMemoryIntent_ForPromotedActionIdWhenExecutionIsNotSdk`).
- Attempted to run deterministic tests with `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --filter "FullyQualifiedName~BackendRouterTests"`, but test execution was skipped because the environment lacks the `dotnet` CLI (`bash: command not found: dotnet`).
- Attempted canonical verification `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --no-build --filter "FullyQualifiedName!~SwfocTrainer.Tests.Profiles.Live&FullyQualifiedName!~RuntimeAttachSmokeTests"`, but it was also blocked for the same reason; tests were updated deterministically and are ready to run in CI where `dotnet` is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a258aca6008332a67791d3eac98f93)