### PR TITLE
Fail-closed extender mutation stubs and preserve diagnostics contract

### DIFF
--- a/native/SwfocExtender.Bridge/src/BridgeHostMain.cpp
+++ b/native/SwfocExtender.Bridge/src/BridgeHostMain.cpp
@@ -170,8 +170,8 @@ bool HasNonEmptyAnchor(
 CapabilityState BuildProbeState(bool available) {
     CapabilityState state {};
     state.available = available;
-    state.state = available ? "Verified" : "Unavailable";
-    state.reasonCode = available ? "CAPABILITY_PROBE_PASS" : "CAPABILITY_REQUIRED_MISSING";
+    state.state = available ? "Experimental" : "Unavailable";
+    state.reasonCode = available ? "CAPABILITY_FEATURE_EXPERIMENTAL" : "CAPABILITY_REQUIRED_MISSING";
     return state;
 }
 

--- a/native/SwfocExtender.Plugins/src/EconomyPlugin.cpp
+++ b/native/SwfocExtender.Plugins/src/EconomyPlugin.cpp
@@ -2,6 +2,22 @@
 
 namespace swfoc::extender::plugins {
 
+namespace {
+
+PluginResult BuildNotImplementedMutationResult(const PluginRequest& request) {
+    PluginResult result {};
+    result.succeeded = false;
+    result.reasonCode = "SAFETY_FAIL_CLOSED";
+    result.hookState = "NOOP";
+    result.message = "Mutation rejected: no process write or patch was applied by economy plugin.";
+    result.diagnostics = {
+        {"featureId", request.featureId},
+        {"processMutationApplied", "false"}};
+    return result;
+}
+
+} // namespace
+
 const char* EconomyPlugin::id() const noexcept {
     return "economy";
 }
@@ -11,7 +27,7 @@ PluginResult EconomyPlugin::execute(const PluginRequest& request) {
         PluginResult result {};
         result.succeeded = false;
         result.reasonCode = "CAPABILITY_REQUIRED_MISSING";
-        result.hookState = "none";
+        result.hookState = "DENIED";
         result.message = "Economy plugin only handles set_credits.";
         result.diagnostics = {{"featureId", request.featureId}};
         return result;
@@ -21,37 +37,23 @@ PluginResult EconomyPlugin::execute(const PluginRequest& request) {
         PluginResult result {};
         result.succeeded = false;
         result.reasonCode = "SAFETY_MUTATION_BLOCKED";
-        result.hookState = "denied";
+        result.hookState = "DENIED";
         result.message = "intValue must be non-negative for set_credits.";
         result.diagnostics = {{"intValue", std::to_string(request.intValue)}};
         return result;
     }
 
-    hookInstalled_.store(true);
     lockEnabled_.store(request.lockValue);
     lockedCreditsValue_.store(request.intValue);
-
-    PluginResult result {};
-    result.succeeded = true;
-    result.reasonCode = "CAPABILITY_PROBE_PASS";
-    result.hookState = request.lockValue ? "HOOK_LOCK" : "HOOK_ONESHOT";
-    result.message = request.lockValue
-        ? "Credits lock activated via extender economy plugin."
-        : "Credits one-shot applied via extender economy plugin.";
-    result.diagnostics = {
-        {"intValue", std::to_string(request.intValue)},
-        {"lockCredits", request.lockValue ? "true" : "false"},
-        {"hookInstalled", "true"}
-    };
-    return result;
+    return BuildNotImplementedMutationResult(request);
 }
 
 CapabilitySnapshot EconomyPlugin::capabilitySnapshot() const {
     CapabilitySnapshot snapshot {};
     CapabilityState state {};
-    state.available = true;
-    state.state = "Verified";
-    state.reasonCode = "CAPABILITY_PROBE_PASS";
+    state.available = false;
+    state.state = "Experimental";
+    state.reasonCode = "CAPABILITY_FEATURE_EXPERIMENTAL";
     snapshot.features.emplace("set_credits", state);
     return snapshot;
 }


### PR DESCRIPTION
### Motivation

- Prevent optimistic "mutation succeeded" responses from native extender plugins when no real process write/patch is performed so runtime safety and diagnostics remain accurate.
- Ensure capability probe snapshots reflect that plugin-backed features are not `Verified` unless there is real mutation+verification logic.
- Preserve and propagate plugin-level reason codes and hook states to the bridge/runtime layers unchanged so C# diagnostics remain authoritative.

### Description

- Updated mutation result behavior in `EconomyPlugin`, `GlobalTogglePlugin`, and `BuildPatchPlugin` to return `succeeded = false`, `reasonCode = "SAFETY_FAIL_CLOSED"`, `hookState = "NOOP"`, and a clear message/diagnostics when no process write/patch is applied (files changed: `native/SwfocExtender.Plugins/src/EconomyPlugin.cpp`, `native/SwfocExtender.Plugins/src/GlobalTogglePlugin.cpp`, `native/SwfocExtender.Plugins/src/BuildPatchPlugin.cpp`).
- Tightened capability snapshots and probe mapping so features are not reported as `Verified` from naive host probes; probe-available entries are now `Experimental` with `CAPABILITY_FEATURE_EXPERIMENTAL` (file changed: `native/SwfocExtender.Bridge/src/BridgeHostMain.cpp`).
- Kept validation/unsupported denials semantics (missing process/anchors/invalid bounds remain `DENIED`); the bridge code path that builds bridge results continues to propagate plugin `reasonCode` and `hookState` into C# diagnostics unchanged.
- Added a deterministic bridge contract test to assert failure propagation (`NamedPipeExtenderBackendTests.ExecuteAsync_ShouldPreserveFailureReasonCodeAndHookState_FromExtenderResponse`) in `tests/SwfocTrainer.Tests/Runtime/NamedPipeExtenderBackendTests.cs`.

### Testing

- Added deterministic unit test: `NamedPipeExtenderBackendTests.ExecuteAsync_ShouldPreserveFailureReasonCodeAndHookState_FromExtenderResponse` which asserts `Succeeded == false`, `reasonCode == "SAFETY_FAIL_CLOSED"`, and `hookState == "NOOP"` are surfaced in runtime diagnostics (test file: `tests/SwfocTrainer.Tests/Runtime/NamedPipeExtenderBackendTests.cs`).
- Attempted to run the repository canonical verification command `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --no-build --filter "FullyQualifiedName!~SwfocTrainer.Tests.Profiles.Live&FullyQualifiedName!~RuntimeAttachSmokeTests"`, but the execution environment lacks the `dotnet` SDK so tests could not be executed here (`dotnet: command not found`).
- Manual repository checks (static inspection and running small local scripts) were performed to validate the change surface and test injection succeeds; deterministic test added but not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a258a8ac5c8332a333710cad24e693)