### PR TITLE
Fail-close extender mutation plugins when process mutation is unimplemented

### DIFF
--- a/native/SwfocExtender.Plugins/src/EconomyPlugin.cpp
+++ b/native/SwfocExtender.Plugins/src/EconomyPlugin.cpp
@@ -2,6 +2,30 @@
 
 namespace swfoc::extender::plugins {
 
+namespace {
+
+constexpr const char* kReasonExtenderNotImplemented = "EXTENDER_NOT_IMPLEMENTED";
+
+bool HasProcessMutationImplementation() {
+    return false;
+}
+
+PluginResult BuildMutationNotImplementedResult(const PluginRequest& request) {
+    PluginResult result {};
+    result.succeeded = false;
+    result.reasonCode = kReasonExtenderNotImplemented;
+    result.hookState = "NOOP";
+    result.message = "Economy mutation rejected because process mutation implementation is not installed.";
+    result.diagnostics = {
+        {"featureId", request.featureId},
+        {"processId", std::to_string(request.processId)},
+        {"anchorsPresent", request.anchors.empty() ? "false" : "true"},
+        {"anchorCount", std::to_string(request.anchors.size())}};
+    return result;
+}
+
+} // namespace
+
 const char* EconomyPlugin::id() const noexcept {
     return "economy";
 }
@@ -25,6 +49,10 @@ PluginResult EconomyPlugin::execute(const PluginRequest& request) {
         result.message = "intValue must be non-negative for set_credits.";
         result.diagnostics = {{"intValue", std::to_string(request.intValue)}};
         return result;
+    }
+
+    if (!HasProcessMutationImplementation()) {
+        return BuildMutationNotImplementedResult(request);
     }
 
     hookInstalled_.store(true);


### PR DESCRIPTION
### Motivation
- Prevent optimistic-success returns from native extender plugins for mutation commands when no concrete process-mutation implementation has actually run, and provide an explicit, machine-parsable failure signal instead.
- Make failures observable and diagnostic by including `featureId`, `processId`, and anchor presence/count so bridge and runtime consumers can make deterministic routing/retry decisions.
- Preserve explicit non-success reason codes for unsupported or safety-blocked input paths (`CAPABILITY_REQUIRED_MISSING`, `SAFETY_MUTATION_BLOCKED`) while changing only the unimplemented-mutation path to fail-closed.

### Description
- Added a gated implementation check and a shared `EXTENDER_NOT_IMPLEMENTED`/`NOOP` failure builder to `EconomyPlugin`, `GlobalTogglePlugin`, and `BuildPatchPlugin`, and `execute(const PluginRequest&)` now returns the fail-closed result when no real mutation path is present (stubs: `HasProcessMutationImplementation()` + `BuildMutationNotImplementedResult(...)`).
- The unimplemented mutation response includes `succeeded=false`, `reasonCode="EXTENDER_NOT_IMPLEMENTED"`, `hookState="NOOP"`, a clear `message`, and diagnostics containing `featureId`, `processId`, `anchorsPresent`, and `anchorCount` as required.
- Kept existing explicit validation/failure branches unchanged for missing feature/process/anchor or safety bounds (`CAPABILITY_REQUIRED_MISSING`, `SAFETY_MUTATION_BLOCKED`) and preserved successful mutation behavior when a concrete path is executed.
- Added a deterministic native-bridge test `ExecuteAsync_ShouldSurfaceExtenderNotImplementedFailureAndNoopHookState` in `tests/SwfocTrainer.Tests/Runtime/NamedPipeExtenderBackendTests.cs` to assert that bridge JSON fields (`reasonCode`, `hookState`, and diagnostics like `anchorsPresent`) are forwarded unchanged to the C# side.

Files touched: `native/SwfocExtender.Plugins/src/EconomyPlugin.cpp`, `native/SwfocExtender.Plugins/src/GlobalTogglePlugin.cpp`, `native/SwfocExtender.Plugins/src/BuildPatchPlugin.cpp`, and `tests/SwfocTrainer.Tests/Runtime/NamedPipeExtenderBackendTests.cs`.

### Testing
- Added a deterministic unit test in `tests/SwfocTrainer.Tests/Runtime/NamedPipeExtenderBackendTests.cs` that simulates an extender response with `EXTENDER_NOT_IMPLEMENTED`/`NOOP` and asserts the runtime receives the fields unchanged.
- Attempted to run the canonical test command `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --no-build --filter "FullyQualifiedName!~SwfocTrainer.Tests.Profiles.Live&FullyQualifiedName!~RuntimeAttachSmokeTests"` but `dotnet` is not available in this environment so tests could not be executed here (error: `bash: command not found: dotnet`).
- To verify locally: run `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --filter "FullyQualifiedName~NamedPipeExtenderBackendTests"` and confirm the new test `ExecuteAsync_ShouldSurfaceExtenderNotImplementedFailureAndNoopHookState` passes along with other `NamedPipeExtenderBackendTests`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a258975870833297314a0b0f1bfdb9)