### PR TITLE
Route SWFOC quick actions to managed backends until native mutation lands

### DIFF
--- a/profiles/default/profiles/aotr_1397421866_swfoc.json
+++ b/profiles/default/profiles/aotr_1397421866_swfoc.json
@@ -6,12 +6,6 @@
   "steamWorkshopId": "1397421866",
   "backendPreference": "auto",
   "requiredCapabilities": [
-    "set_credits",
-    "freeze_timer",
-    "toggle_fog_reveal",
-    "toggle_ai",
-    "set_unit_cap",
-    "toggle_instant_build_patch",
     "set_hero_state_helper"
   ],
   "hostPreference": "starwarsg_preferred",
@@ -82,6 +76,7 @@
     "requiredMarkerFile": "Data/XML/Gameobjectfiles.xml",
     "dependencySensitiveActions": "spawn_unit_helper,set_hero_state_helper",
     "localPathHints": "aotr,awakening of the rebellion,awakening-of-the-rebellion,1397421866",
-    "profileAliases": "aotr_1397421866_swfoc,aotr,awakening"
+    "profileAliases": "aotr_1397421866_swfoc,aotr,awakening",
+    "quickActionBackendCompatibility": "inherits base_swfoc managed quick-action routing (Memory/CodePatch)"
   }
 }

--- a/profiles/default/profiles/base_swfoc.json
+++ b/profiles/default/profiles/base_swfoc.json
@@ -5,14 +5,7 @@
   "exeTarget": "Swfoc",
   "steamWorkshopId": null,
   "backendPreference": "auto",
-  "requiredCapabilities": [
-    "set_credits",
-    "freeze_timer",
-    "toggle_fog_reveal",
-    "toggle_ai",
-    "set_unit_cap",
-    "toggle_instant_build_patch"
-  ],
+  "requiredCapabilities": [],
   "hostPreference": "starwarsg_preferred",
   "experimentalFeatures": [
     "game_speed",
@@ -83,7 +76,7 @@
       "id": "set_credits",
       "category": "Economy",
       "mode": "Unknown",
-      "executionKind": "Sdk",
+      "executionKind": "Memory",
       "payloadSchema": {
         "required": ["symbol", "intValue"]
       },
@@ -95,7 +88,7 @@
       "id": "freeze_timer",
       "category": "Global",
       "mode": "Unknown",
-      "executionKind": "Sdk",
+      "executionKind": "Memory",
       "payloadSchema": {
         "required": ["symbol", "boolValue"]
       },
@@ -107,7 +100,7 @@
       "id": "toggle_fog_reveal",
       "category": "Global",
       "mode": "Unknown",
-      "executionKind": "Sdk",
+      "executionKind": "Memory",
       "payloadSchema": {
         "required": ["symbol", "boolValue"]
       },
@@ -119,7 +112,7 @@
       "id": "toggle_ai",
       "category": "Global",
       "mode": "Unknown",
-      "executionKind": "Sdk",
+      "executionKind": "Memory",
       "payloadSchema": {
         "required": ["symbol", "boolValue"]
       },
@@ -287,7 +280,7 @@
       "id": "set_unit_cap",
       "category": "Global",
       "mode": "Unknown",
-      "executionKind": "Sdk",
+      "executionKind": "CodePatch",
       "payloadSchema": {
         "required": ["intValue"]
       },
@@ -299,7 +292,7 @@
       "id": "toggle_instant_build_patch",
       "category": "Global",
       "mode": "Unknown",
-      "executionKind": "Sdk",
+      "executionKind": "CodePatch",
       "payloadSchema": {
         "required": ["enable"]
       },
@@ -391,6 +384,7 @@
     "profileAliases": "base_swfoc,swfoc,forces of corruption,foc",
     "localPathHints": "swfoc,corruption,forces of corruption",
     "criticalSymbols": "credits,planet_owner,hero_respawn_timer,game_speed,unit_cap",
-    "symbolValidationRules": "[{\"Symbol\":\"credits\",\"IntMin\":0,\"IntMax\":2000000000,\"Critical\":true},{\"Symbol\":\"planet_owner\",\"IntMin\":0,\"IntMax\":16,\"Critical\":true},{\"Symbol\":\"hero_respawn_timer\",\"IntMin\":0,\"IntMax\":86400,\"Critical\":true},{\"Symbol\":\"game_speed\",\"FloatMin\":0.05,\"FloatMax\":8.0,\"Critical\":true},{\"Symbol\":\"selected_hp\",\"Mode\":\"Tactical\",\"FloatMin\":0.0,\"FloatMax\":5000000.0},{\"Symbol\":\"selected_shield\",\"Mode\":\"Tactical\",\"FloatMin\":0.0,\"FloatMax\":5000000.0}]"
+    "symbolValidationRules": "[{\"Symbol\":\"credits\",\"IntMin\":0,\"IntMax\":2000000000,\"Critical\":true},{\"Symbol\":\"planet_owner\",\"IntMin\":0,\"IntMax\":16,\"Critical\":true},{\"Symbol\":\"hero_respawn_timer\",\"IntMin\":0,\"IntMax\":86400,\"Critical\":true},{\"Symbol\":\"game_speed\",\"FloatMin\":0.05,\"FloatMax\":8.0,\"Critical\":true},{\"Symbol\":\"selected_hp\",\"Mode\":\"Tactical\",\"FloatMin\":0.0,\"FloatMax\":5000000.0},{\"Symbol\":\"selected_shield\",\"Mode\":\"Tactical\",\"FloatMin\":0.0,\"FloatMax\":5000000.0}]",
+    "quickActionBackendCompatibility": "base/aotr/roe quick actions route through managed Memory or CodePatch paths until native mutation is complete"
   }
 }

--- a/profiles/default/profiles/roe_3447786229_swfoc.json
+++ b/profiles/default/profiles/roe_3447786229_swfoc.json
@@ -6,12 +6,6 @@
   "steamWorkshopId": "3447786229",
   "backendPreference": "auto",
   "requiredCapabilities": [
-    "set_credits",
-    "freeze_timer",
-    "toggle_fog_reveal",
-    "toggle_ai",
-    "set_unit_cap",
-    "toggle_instant_build_patch",
     "set_hero_state_helper",
     "toggle_roe_respawn_helper"
   ],
@@ -83,6 +77,7 @@
     "dependencySensitiveActions": "spawn_unit_helper,set_hero_state_helper,toggle_roe_respawn_helper",
     "localPathHints": "roe,order 66,order-66,3447786229",
     "localParentPathHints": "1397421866,aotr,awakening of the rebellion,awakening-of-the-rebellion",
-    "profileAliases": "roe_3447786229_swfoc,roe,order66,order 66 submod"
+    "profileAliases": "roe_3447786229_swfoc,roe,order66,order 66 submod",
+    "quickActionBackendCompatibility": "inherits base_swfoc managed quick-action routing (Memory/CodePatch)"
   }
 }


### PR DESCRIPTION
### Motivation

- Quick actions that previously required extender/native mutation were failing under capability-probe uncertainty, so route them through known-working managed paths until native mutation is complete. 
- Avoid incorrectly requiring extender-only capability for non-SDK (managed) actions by updating the `requiredCapabilities` contract on the SWFOC lineage. 
- Keep compatibility notes explicit for `base`, `aotr`, and `roe` variants so behavior changes are discoverable and reversible.

### Description

- Changed execution kinds in `profiles/default/profiles/base_swfoc.json`: `set_credits`, `freeze_timer`, `toggle_fog_reveal`, and `toggle_ai` from `Sdk` to `Memory`, and `set_unit_cap` and `toggle_instant_build_patch` from `Sdk` to `CodePatch`. 
- Cleared quick-action entries from `requiredCapabilities` on `base_swfoc` and removed those quick-action requirements from `aotr_1397421866_swfoc` and `roe_3447786229_swfoc`, leaving helper-specific requirements intact (`set_hero_state_helper` and `toggle_roe_respawn_helper`). 
- Added `metadata.quickActionBackendCompatibility` notes to `base_swfoc`, `aotr_1397421866_swfoc`, and `roe_3447786229_swfoc` documenting that quick actions currently route through managed `Memory`/`CodePatch` paths until native mutation is available. 
- Updated tests in `tests/SwfocTrainer.Tests/Profiles/ProfileActionCatalogTests.cs` to assert the new execution kinds and to assert that SWFOC profiles no longer require promoted quick-action extender capabilities. 
- Affected profile IDs: `base_swfoc`, `aotr_1397421866_swfoc`, `roe_3447786229_swfoc`; reason-code diagnostics impact: this reduces occurrences of `CAPABILITY_REQUIRED_MISSING` and `SAFETY_FAIL_CLOSED` for these quick actions and aligns router fallback behavior to `Memory`/`CodePatch`.

### Testing

- Updated unit tests: `tests/SwfocTrainer.Tests/Profiles/ProfileActionCatalogTests.cs` were modified to match the new execution-kind and capability expectations (no test run performed here due to environment constraints). 
- Attempted to run the canonical deterministic test command but skipped because the `dotnet` CLI is unavailable in this environment; attempted command: `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --filter "FullyQualifiedName~ProfileActionCatalogTests"`. 
- Verified file changes and committed the branch, and created the PR with the change-set (commit `6fd1ea3`) and diffs reviewed locally (`git show --stat`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2589f3ea483328bab9f44d186f2e4)