### PR TITLE
Gate FoC promoted extender routing on SDK execution kind

### DIFF
--- a/src/SwfocTrainer.Runtime/Services/RuntimeAdapter.cs
+++ b/src/SwfocTrainer.Runtime/Services/RuntimeAdapter.cs
@@ -1541,8 +1541,25 @@ public sealed class RuntimeAdapter : IRuntimeAdapter
     {
         return !routeDecision.Allowed &&
                routeDecision.Backend == ExecutionBackendKind.Extender &&
-               IsPromotedExtenderAction(request.Action.Id) &&
+               IsRouterPromotedExtenderAction(routeDecision.Diagnostics) &&
                IsMutatingActionId(request.Action.Id);
+    }
+
+    private static bool IsRouterPromotedExtenderAction(IReadOnlyDictionary<string, object?>? diagnostics)
+    {
+        if (diagnostics is null ||
+            !diagnostics.TryGetValue("promotedExtenderAction", out var raw) ||
+            raw is null)
+        {
+            return false;
+        }
+
+        if (raw is bool promoted)
+        {
+            return promoted;
+        }
+
+        return bool.TryParse(raw.ToString(), out var parsed) && parsed;
     }
 
     private static ExecutionBackendKind ResolveLegacyOverrideBackend(ExecutionKind executionKind)

--- a/tests/SwfocTrainer.Tests/Profiles/LivePromotedActionMatrixTests.cs
+++ b/tests/SwfocTrainer.Tests/Profiles/LivePromotedActionMatrixTests.cs
@@ -228,7 +228,8 @@ public sealed class LivePromotedActionMatrixTests
             routeReasonCode,
             capabilityProbeReasonCode,
             hybridExecution,
-            hasFallbackMarker);
+            hasFallbackMarker,
+            action.ExecutionKind);
     }
 
     private bool TrySkipUnavailableProfileContext(
@@ -258,13 +259,17 @@ public sealed class LivePromotedActionMatrixTests
         string? routeReasonCode,
         string? capabilityProbeReasonCode,
         bool? hybridExecution,
-        bool hasFallbackMarker)
+        bool hasFallbackMarker,
+        ExecutionKind executionKind)
     {
         result.Succeeded.Should().BeTrue(
             $"promoted action '{actionId}' should execute successfully for profile '{profileId}'. message={result.Message}");
+        var expectedBackend = executionKind == ExecutionKind.Sdk
+            ? ExecutionBackendKind.Extender
+            : ExecutionBackendKind.Memory;
         backendRoute.Should().Be(
-            ExecutionBackendKind.Extender.ToString(),
-            because: $"promoted action '{actionId}' should route via extender backend for profile '{profileId}'.");
+            expectedBackend.ToString(),
+            because: $"promoted action '{actionId}' should respect execution kind '{executionKind}' for profile '{profileId}'.");
         routeReasonCode.Should().Be(
             RuntimeReasonCode.CAPABILITY_PROBE_PASS.ToString(),
             because: $"promoted action '{actionId}' should pass route capability gate for profile '{profileId}'.");


### PR DESCRIPTION
### Motivation

- Prevent promoted FoC action IDs from unconditionally forcing extender routing when the action's `ExecutionKind` is not `Sdk`, while preserving existing safety (fail-closed) semantics for genuine SDK-backed promoted mutations. 
- Allow explicit, per-profile promotion opt-in for non-SDK actions via profile metadata so teams can opt into extender routing when intentionally configured.

### Description

- Change `BackendRouter` promotion logic to accept the full `ActionSpec` and only treat built-in promoted IDs as forced-extender when `action.ExecutionKind == ExecutionKind.Sdk`, or when explicit profile metadata opts the action in; this adds `IsExplicitlyPromotedFromProfileMetadata(...)` and updates `IsPromotedExtenderAction(...)` accordingly. 
- Keep fail-closed verification for truly promoted SDK mutations (the promoted capability gate and required-capability contract behavior remain intact). 
- Update `RuntimeAdapter` expert-override eligibility to consult the router-computed `promotedExtenderAction` diagnostic (via `IsRouterPromotedExtenderAction(...)`) instead of checking action ID directly so runtime override behavior follows router decisions. 
- Update tests: `BackendRouterTests` now asserts promotion only for SDK execution kinds, adds tests that Memory/CodePatch promoted IDs do not force extender routing, and adds an explicit-profile-metadata promotion test; `LivePromotedActionMatrixTests` assertion now derives expected backend from `Action.ExecutionKind` (SDK => Extender, non-SDK => Memory). 

Files touched: `src/SwfocTrainer.Runtime/Services/BackendRouter.cs`, `src/SwfocTrainer.Runtime/Services/RuntimeAdapter.cs`, `tests/SwfocTrainer.Tests/Runtime/BackendRouterTests.cs`, and `tests/SwfocTrainer.Tests/Profiles/LivePromotedActionMatrixTests.cs`.

### Testing

- Added deterministic unit tests in `BackendRouterTests` covering SDK-only promotion, non-SDK non-promotion, and explicit metadata-based promotion, and adjusted `LivePromotedActionMatrixTests` assertions to be execution-kind aware; these tests were committed with code changes. 
- Attempted to run unit tests using the canonical command `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --no-build --filter "FullyQualifiedName!~SwfocTrainer.Tests.Profiles.Live&FullyQualifiedName!~RuntimeAttachSmokeTests"`, but the runner environment does not have the `dotnet` CLI installed (`bash: command not found: dotnet`), so automated test execution could not be performed here. 
- Performed repository checks (`git diff --check`) and committed the changes (commit recorded as `bc91155`), so the modified tests and code are ready for CI or a local machine with `dotnet` to validate.

Risk: `risk:low`.

Affected FoC profile IDs (examples): `base_swfoc`, `aotr_1397421866_swfoc`, `roe_3447786229_swfoc`.

Notes for reviewer: run the canonical verification command locally or in CI to validate the new tests and ensure no regressions in routing behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2589b92348332b03aed2d96e63678)