### PR TITLE
Refine extender capability probe to gate by implementation maturity

### DIFF
--- a/tests/SwfocTrainer.Tests/Runtime/BackendRouterTests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/BackendRouterTests.cs
@@ -124,6 +124,10 @@ public sealed class BackendRouterTests
         decision.Diagnostics!["hybridExecution"].Should().Be(false);
         decision.Diagnostics.Should().ContainKey("promotedExtenderAction");
         decision.Diagnostics!["promotedExtenderAction"].Should().Be(true);
+        decision.Diagnostics.Should().ContainKey("promotedCapabilityGate");
+        decision.Diagnostics!["promotedCapabilityGate"].Should().Be("unverified");
+        decision.Diagnostics.Should().ContainKey("promotedCapabilityReasonCode");
+        decision.Diagnostics!["promotedCapabilityReasonCode"].Should().Be(nameof(RuntimeReasonCode.CAPABILITY_FEATURE_EXPERIMENTAL));
         decision.Diagnostics.Should().NotContainKey("fallbackBackend");
     }
 

--- a/tests/SwfocTrainer.Tests/Runtime/NamedPipeExtenderBackendTests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/NamedPipeExtenderBackendTests.cs
@@ -239,7 +239,7 @@ public sealed class NamedPipeExtenderBackendTests
                     toggle_fog_reveal = new { available = true, state = "Verified", reasonCode = "CAPABILITY_PROBE_PASS" },
                     toggle_ai = new { available = false, state = "Unknown", reasonCode = "CAPABILITY_REQUIRED_MISSING" },
                     set_unit_cap = new { available = true, state = "Experimental", reasonCode = "CAPABILITY_FEATURE_EXPERIMENTAL" },
-                    toggle_instant_build_patch = new { available = false, state = "Unknown", reasonCode = "CAPABILITY_REQUIRED_MISSING" },
+                    toggle_instant_build_patch = new { available = true, state = "Experimental", reasonCode = "CAPABILITY_FEATURE_EXPERIMENTAL" },
                     set_credits = new { available = true, state = "Verified", reasonCode = "CAPABILITY_PROBE_PASS" }
                 }
             }
@@ -257,6 +257,9 @@ public sealed class NamedPipeExtenderBackendTests
         report.IsFeatureAvailable("set_credits").Should().BeTrue(
             $"probeReason={report.ProbeReasonCode} diagnostics={System.Text.Json.JsonSerializer.Serialize(report.Diagnostics)}");
         report.Capabilities["set_unit_cap"].Confidence.Should().Be(CapabilityConfidenceState.Experimental);
+        report.Capabilities["set_unit_cap"].ReasonCode.Should().Be(RuntimeReasonCode.CAPABILITY_FEATURE_EXPERIMENTAL);
+        report.Capabilities["toggle_instant_build_patch"].Confidence.Should().Be(CapabilityConfidenceState.Experimental);
+        report.Capabilities["toggle_instant_build_patch"].ReasonCode.Should().Be(RuntimeReasonCode.CAPABILITY_FEATURE_EXPERIMENTAL);
         report.Capabilities["set_credits"].Confidence.Should().Be(CapabilityConfidenceState.Verified);
     }
 


### PR DESCRIPTION
### Motivation
- The bridge probe previously treated a feature as available if anchors/process were present, which conflated addressability with mutation readiness.
- Promoted mutating actions need a deterministic maturity signal so routing can fail-closed when mutation implementation is not verified.
- Tests and runtime routing depend on explicit reason-code/state contracts for safe gating and diagnostics.

### Description
- Change probe classification in `native/SwfocExtender.Bridge/src/BridgeHostMain.cpp` to separate process addressability, anchor addressability, and mutation implementation readiness by adding `IsMutationImplementationReady` and expanding `AddProbeFeature` logic. 
- Report deterministic states/reason-codes: `CAPABILITY_BACKEND_UNAVAILABLE` when no `processId` is present, `CAPABILITY_REQUIRED_MISSING` when anchors are missing, `CAPABILITY_FEATURE_EXPERIMENTAL` when addressable but implementation is not mature, and `CAPABILITY_PROBE_PASS` for verified features. 
- Update tests to reflect the new contract by modifying `tests/SwfocTrainer.Tests/Runtime/NamedPipeExtenderBackendTests.cs` and `tests/SwfocTrainer.Tests/Runtime/BackendRouterTests.cs` so probe parsing and promoted-route diagnostics assert experimental reason codes and gate diagnostics. 
- Ensure promoted action routing continues to fail-closed when capability is not verified and now emits explicit diagnostics (`promotedCapabilityGate=unverified`, `promotedCapabilityReasonCode=CAPABILITY_FEATURE_EXPERIMENTAL`).

### Testing
- Updated unit tests: `NamedPipeExtenderBackendTests` and `BackendRouterTests` were adjusted to assert the new state/reason-code behavior and additional diagnostics; these tests were changed in the commit but could not be executed here. 
- Attempted to run focused tests via `dotnet test ...FullyQualifiedName~SwfocTrainer.Tests.Runtime.NamedPipeExtenderBackendTests|...BackendRouterTests`, but the environment lacked the `dotnet` runtime (`dotnet: command not found`), so automated test execution failed. 
- Tests were kept deterministic (same inputs yield the same probe outputs) and all changes are limited and reversible to preserve safety and allow local CI verification before merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2589964148332b9c15a84948c14fc)