### PR TITLE
Add operator runtime mode override and honor it in runtime adapter

### DIFF
--- a/src/SwfocTrainer.App/MainWindow.xaml
+++ b/src/SwfocTrainer.App/MainWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:SwfocTrainer.Core.Models;assembly=SwfocTrainer.Core"
         mc:Ignorable="d"
         Title="SWFOC Trainer Editor" Height="900" Width="1400"
         MinWidth="1024" MinHeight="700"
@@ -24,6 +25,12 @@
             <Button Content="Detach" Command="{Binding DetachCommand}" Margin="8,0,0,0"/>
             <TextBlock Text="  Mode:" VerticalAlignment="Center" Margin="12,0,4,0"/>
             <TextBlock Text="{Binding RuntimeMode}" VerticalAlignment="Center"/>
+            <TextBlock Text="  Override:" VerticalAlignment="Center" Margin="12,0,4,0"/>
+            <ComboBox Width="110" SelectedValuePath="Tag" SelectedValue="{Binding RuntimeModeOverride}">
+                <ComboBoxItem Content="Unknown" Tag="{x:Static local:RuntimeMode.Unknown}"/>
+                <ComboBoxItem Content="Galactic" Tag="{x:Static local:RuntimeMode.Galactic}"/>
+                <ComboBoxItem Content="Tactical" Tag="{x:Static local:RuntimeMode.Tactical}"/>
+            </ComboBox>
             <TextBlock Text="  Symbols:" VerticalAlignment="Center" Margin="12,0,4,0"/>
             <TextBlock Text="{Binding ResolvedSymbolsCount}" VerticalAlignment="Center"/>
         </StackPanel>

--- a/src/SwfocTrainer.App/ViewModels/MainViewModel.cs
+++ b/src/SwfocTrainer.App/ViewModels/MainViewModel.cs
@@ -468,7 +468,7 @@ public sealed class MainViewModel : MainViewModelSaveOpsBase
                 SelectedProfileId,
                 SelectedActionId,
                 payloadNode,
-                RuntimeMode,
+                ResolveRuntimeModeForExecution(),
                 BuildActionContext(SelectedActionId));
             Status = result.Succeeded
                 ? $"Action succeeded: {result.Message}{MainViewModelDiagnostics.BuildDiagnosticsStatusSuffix(result)}"

--- a/src/SwfocTrainer.App/ViewModels/MainViewModelBindableMembersBase.cs
+++ b/src/SwfocTrainer.App/ViewModels/MainViewModelBindableMembersBase.cs
@@ -71,6 +71,12 @@ public abstract class MainViewModelBindableMembersBase : MainViewModelCoreStateB
         set => SetField(_runtimeMode, value, newValue => _runtimeMode = newValue);
     }
 
+    public RuntimeMode RuntimeModeOverride
+    {
+        get => _runtimeModeOverride;
+        set => SetField(_runtimeModeOverride, value, newValue => _runtimeModeOverride = newValue);
+    }
+
     public string SavePath
     {
         get => _savePath;

--- a/src/SwfocTrainer.App/ViewModels/MainViewModelCoreStateBase.cs
+++ b/src/SwfocTrainer.App/ViewModels/MainViewModelCoreStateBase.cs
@@ -78,6 +78,7 @@ public abstract class MainViewModelCoreStateBase : INotifyPropertyChanged
     protected string _selectedActionId = string.Empty;
     protected string _payloadJson = MainViewModelDefaults.DefaultPayloadJsonTemplate;
     protected RuntimeMode _runtimeMode = RuntimeMode.Unknown;
+    protected RuntimeMode _runtimeModeOverride = RuntimeMode.Unknown;
     protected string _savePath = string.Empty;
     protected string _saveNodePath = string.Empty;
     protected string _saveEditValue = string.Empty;

--- a/src/SwfocTrainer.App/ViewModels/MainViewModelQuickActionsBase.cs
+++ b/src/SwfocTrainer.App/ViewModels/MainViewModelQuickActionsBase.cs
@@ -48,7 +48,7 @@ public abstract class MainViewModelQuickActionsBase : MainViewModelLiveOpsBase
             SelectedProfileId!,
             actionId,
             payload,
-            RuntimeMode,
+            ResolveRuntimeModeForExecution(),
             BuildActionContext(actionId));
     }
 
@@ -151,7 +151,7 @@ public abstract class MainViewModelQuickActionsBase : MainViewModelLiveOpsBase
         SelectedProfileId!,
         ActionSetCredits,
         payload,
-        RuntimeMode,
+        ResolveRuntimeModeForExecution(),
         BuildActionContext(ActionSetCredits));
 
     protected Task QuickFreezeTimerAsync() => QuickRunActionAsync(
@@ -288,7 +288,7 @@ public abstract class MainViewModelQuickActionsBase : MainViewModelLiveOpsBase
             SelectedProfileId!,
             binding.ActionId,
             payloadNode,
-            RuntimeMode,
+            ResolveRuntimeModeForExecution(),
             BuildActionContext(binding.ActionId));
         Status = MainViewModelHotkeyHelpers.BuildHotkeyStatus(gesture, binding.ActionId, result);
 

--- a/tests/SwfocTrainer.Tests/Runtime/RuntimeAdapterModeOverrideTests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/RuntimeAdapterModeOverrideTests.cs
@@ -1,0 +1,108 @@
+using System.Reflection;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using SwfocTrainer.Core.Models;
+using SwfocTrainer.Runtime.Services;
+using Xunit;
+
+namespace SwfocTrainer.Tests.Runtime;
+
+public sealed class RuntimeAdapterModeOverrideTests
+{
+    [Fact]
+    public void ApplyRuntimeModeOverride_ShouldKeepRequestedMode_WhenOverrideIsNotProvided()
+    {
+        var request = BuildRequest(
+            RuntimeMode.Tactical,
+            new Dictionary<string, object?>());
+
+        var applied = InvokeApplyRuntimeModeOverride(
+            request,
+            new Dictionary<string, string>
+            {
+                ["runtimeModeHint"] = RuntimeMode.Galactic.ToString(),
+                ["runtimeModeReasonCode"] = "mode_probe_galactic_signals"
+            });
+
+        applied.RuntimeMode.Should().Be(RuntimeMode.Tactical);
+        applied.Context!["runtimeModeHint"].Should().Be("Galactic");
+        applied.Context["runtimeModeEffective"].Should().Be("Tactical");
+        applied.Context["runtimeModeReasonCode"].Should().Be("mode_probe_galactic_signals");
+    }
+
+    [Fact]
+    public void ApplyRuntimeModeOverride_ShouldUseOverrideMode_ForGating()
+    {
+        var request = BuildRequest(
+            RuntimeMode.Tactical,
+            new Dictionary<string, object?>
+            {
+                ["runtimeModeOverride"] = RuntimeMode.Galactic.ToString()
+            });
+
+        var applied = InvokeApplyRuntimeModeOverride(
+            request,
+            new Dictionary<string, string>
+            {
+                ["runtimeModeHint"] = RuntimeMode.Tactical.ToString(),
+                ["runtimeModeReasonCode"] = "mode_probe_tactical_signals"
+            });
+
+        applied.RuntimeMode.Should().Be(RuntimeMode.Galactic, "operator override should drive mode-gated routing checks.");
+        applied.Context!["runtimeModeReasonCode"].Should().Be("mode_override_operator");
+    }
+
+    [Fact]
+    public void ApplyRuntimeModeOverride_ShouldEmitRequestedAndEffectiveDiagnostics()
+    {
+        var request = BuildRequest(
+            RuntimeMode.Unknown,
+            new Dictionary<string, object?>
+            {
+                ["runtimeModeOverride"] = RuntimeMode.Tactical
+            });
+
+        var applied = InvokeApplyRuntimeModeOverride(request, sessionMetadata: null);
+
+        applied.Context.Should().NotBeNull();
+        applied.Context.Should().ContainKey("runtimeModeRequested");
+        applied.Context.Should().ContainKey("runtimeModeHint");
+        applied.Context.Should().ContainKey("runtimeModeEffective");
+        applied.Context.Should().ContainKey("runtimeModeReasonCode");
+        applied.Context!["runtimeModeRequested"].Should().Be("Unknown");
+        applied.Context["runtimeModeEffective"].Should().Be("Tactical");
+    }
+
+    private static ActionExecutionRequest BuildRequest(RuntimeMode runtimeMode, IReadOnlyDictionary<string, object?>? context)
+    {
+        var action = new ActionSpec(
+            Id: "set_planet_owner",
+            Category: ActionCategory.Global,
+            Mode: RuntimeMode.Galactic,
+            ExecutionKind: ExecutionKind.Sdk,
+            PayloadSchema: new JsonObject(),
+            VerifyReadback: false,
+            CooldownMs: 0);
+
+        return new ActionExecutionRequest(
+            Action: action,
+            Payload: new JsonObject(),
+            ProfileId: "test_profile",
+            RuntimeMode: runtimeMode,
+            Context: context);
+    }
+
+    private static ActionExecutionRequest InvokeApplyRuntimeModeOverride(
+        ActionExecutionRequest request,
+        IReadOnlyDictionary<string, string>? sessionMetadata)
+    {
+        var method = typeof(RuntimeAdapter).GetMethod(
+            "ApplyRuntimeModeOverride",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        method.Should().NotBeNull();
+        var applied = method!.Invoke(null, new object?[] { request, sessionMetadata });
+        applied.Should().BeOfType<ActionExecutionRequest>();
+        return (ActionExecutionRequest)applied!;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an operator-controlled source for runtime mode to allow explicit execution gating (Unknown/Galactic/Tactical) in addition to the existing inferred probe. This lets operators unblock or force mode-gated actions in a controlled, observable way. Affected profiles: `base`, `aotr`, `roe`, and `custom` because mode gating for action execution is profile-agnostic. 
- Preserve supportability: keep the inferred-mode metadata (diagnostics keys) so support bundles remain informative and can show whether the effective mode came from inference or operator override.
- Emit a clear reason-code for operator overrides so downstream diagnostics can distinguish inferred vs operator-driven gating decisions.

### Description
- Added an operator override field and binding in the app view model and UI: `RuntimeModeOverride` property and a top-bar ComboBox (Unknown/Galactic/Tactical) in `MainWindow.xaml`. (files changed: `src/SwfocTrainer.App/ViewModels/MainViewModelCoreStateBase.cs`, `src/SwfocTrainer.App/ViewModels/MainViewModelBindableMembersBase.cs`, `src/SwfocTrainer.App/MainWindow.xaml`).
- Threaded override into execution flows by introducing `ResolveRuntimeModeForExecution()` and using it for action dispatch paths (regular actions, quick actions, hotkeys, selected-unit ops, spawn batches). (files changed: `src/SwfocTrainer.App/ViewModels/MainViewModel.cs`, `src/SwfocTrainer.App/ViewModels/MainViewModelQuickActionsBase.cs`, `src/SwfocTrainer.App/ViewModels/MainViewModelLiveOpsBase.cs`).
- Implemented override-first logic in runtime adapter: `ApplyRuntimeModeOverride` inspects request context for `runtimeModeOverride`, computes the effective `RuntimeMode`, and preserves/attaches diagnostic metadata (`runtimeModeRequested`, `runtimeModeHint`, `runtimeModeEffective`, `runtimeModeReasonCode`). The runtime then proceeds using the effective mode for routing/gating. (file changed: `src/SwfocTrainer.Runtime/Services/RuntimeAdapter.cs`).
- Added deterministic unit tests exercising override behavior and diagnostics: `tests/SwfocTrainer.Tests/Runtime/RuntimeAdapterModeOverrideTests.cs` which covers: no-override path unchanged, override forces gating mode, and diagnostics emission. Also added context keys `runtimeModeRequested` and `runtimeModeOverride` to action context emitted for observability.

### Testing
- Added deterministic tests: `RuntimeAdapterModeOverrideTests` (file: `tests/SwfocTrainer.Tests/Runtime/RuntimeAdapterModeOverrideTests.cs`) which assert: no-override preserves requested mode, operator override becomes effective for gating, and diagnostics include `runtimeModeRequested`, `runtimeModeHint`, `runtimeModeEffective`, and `runtimeModeReasonCode` (`mode_override_operator` when overridden). Tests were added but not executed in this environment because the `dotnet` CLI is not available here. Command attempted: `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --no-build --filter "FullyQualifiedName!~SwfocTrainer.Tests.Profiles.Live&FullyQualifiedName!~RuntimeAttachSmokeTests"` which failed with `bash: dotnet: command not found`.
- Commands used to validate changes locally (intended canonical verification): `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --no-build --filter "FullyQualifiedName!~SwfocTrainer.Tests.Profiles.Live&FullyQualifiedName!~RuntimeAttachSmokeTests"` (could not run in container); please run this in CI or a local environment with .NET SDK installed.
- Note: All changes are additive and preserve inferred-mode metadata; reason-code emitted for operator overrides is `mode_override_operator` and the hint key remains `runtimeModeHint` for support bundles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a258b0ed088332bdf38e92d80f69ad)