### PR TITLE
Add manual runtime mode override path (Auto/Galactic/Tactical)

### DIFF
--- a/src/SwfocTrainer.App/MainWindow.xaml
+++ b/src/SwfocTrainer.App/MainWindow.xaml
@@ -24,6 +24,12 @@
             <Button Content="Detach" Command="{Binding DetachCommand}" Margin="8,0,0,0"/>
             <TextBlock Text="  Mode:" VerticalAlignment="Center" Margin="12,0,4,0"/>
             <TextBlock Text="{Binding RuntimeMode}" VerticalAlignment="Center"/>
+            <TextBlock Text="  Override:" VerticalAlignment="Center" Margin="12,0,4,0"/>
+            <ComboBox Width="120"
+                      ItemsSource="{Binding RuntimeModeOverrideOptions}"
+                      SelectedItem="{Binding RuntimeModeOverride, UpdateSourceTrigger=PropertyChanged}"/>
+            <TextBlock Text="  Effective:" VerticalAlignment="Center" Margin="8,0,4,0"/>
+            <TextBlock Text="{Binding EffectiveRuntimeMode}" VerticalAlignment="Center"/>
             <TextBlock Text="  Symbols:" VerticalAlignment="Center" Margin="12,0,4,0"/>
             <TextBlock Text="{Binding ResolvedSymbolsCount}" VerticalAlignment="Center"/>
         </StackPanel>

--- a/src/SwfocTrainer.App/Properties/AssemblyInfo.cs
+++ b/src/SwfocTrainer.App/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SwfocTrainer.Tests")]

--- a/src/SwfocTrainer.App/ViewModels/MainViewModel.cs
+++ b/src/SwfocTrainer.App/ViewModels/MainViewModel.cs
@@ -15,6 +15,7 @@ public sealed class MainViewModel : MainViewModelSaveOpsBase
         : base(dependencies)
     {
         (Profiles, Actions, CatalogSummary, Updates, SaveDiffPreview, Hotkeys, SaveFields, FilteredSaveFields, SavePatchOperations, SavePatchCompatibility, ActionReliability, SelectedUnitTransactions, SpawnPresets, LiveOpsDiagnostics, ModCompatibilityRows, ActiveFreezes) = MainViewModelFactories.CreateCollections();
+        RuntimeModeOverride = MainViewModelRuntimeModeOverrideHelpers.Load();
 
         var commandContexts = CreateCommandContexts();
         (LoadProfilesCommand, AttachCommand, DetachCommand, LoadActionsCommand, ExecuteActionCommand, LoadCatalogCommand, DeployHelperCommand, VerifyHelperCommand, CheckUpdatesCommand, InstallUpdateCommand, RollbackProfileUpdateCommand) = MainViewModelFactories.CreateCoreCommands(commandContexts.Core);
@@ -468,7 +469,7 @@ public sealed class MainViewModel : MainViewModelSaveOpsBase
                 SelectedProfileId,
                 SelectedActionId,
                 payloadNode,
-                RuntimeMode,
+                EffectiveRuntimeMode,
                 BuildActionContext(SelectedActionId));
             Status = result.Succeeded
                 ? $"Action succeeded: {result.Message}{MainViewModelDiagnostics.BuildDiagnosticsStatusSuffix(result)}"

--- a/src/SwfocTrainer.App/ViewModels/MainViewModelBindableMembersBase.cs
+++ b/src/SwfocTrainer.App/ViewModels/MainViewModelBindableMembersBase.cs
@@ -68,8 +68,32 @@ public abstract class MainViewModelBindableMembersBase : MainViewModelCoreStateB
     public RuntimeMode RuntimeMode
     {
         get => _runtimeMode;
-        set => SetField(_runtimeMode, value, newValue => _runtimeMode = newValue);
+        set
+        {
+            if (SetField(_runtimeMode, value, newValue => _runtimeMode = newValue))
+            {
+                OnPropertyChanged(nameof(EffectiveRuntimeMode));
+            }
+        }
     }
+
+    public string RuntimeModeOverride
+    {
+        get => _runtimeModeOverride;
+        set
+        {
+            var normalized = MainViewModelRuntimeModeOverrideHelpers.Normalize(value);
+            if (!SetField(_runtimeModeOverride, normalized, newValue => _runtimeModeOverride = newValue))
+            {
+                return;
+            }
+
+            MainViewModelRuntimeModeOverrideHelpers.Save(normalized);
+            OnPropertyChanged(nameof(EffectiveRuntimeMode));
+        }
+    }
+
+    public RuntimeMode EffectiveRuntimeMode => MainViewModelRuntimeModeOverrideHelpers.ResolveEffectiveRuntimeMode(RuntimeMode, RuntimeModeOverride);
 
     public string SavePath
     {
@@ -132,6 +156,9 @@ public abstract class MainViewModelBindableMembersBase : MainViewModelCoreStateB
     }
 
     public bool CanWorkWithProfile => !string.IsNullOrWhiteSpace(SelectedProfileId);
+
+    public IReadOnlyList<string> RuntimeModeOverrideOptions => MainViewModelRuntimeModeOverrideHelpers.ModeOverrideOptions;
+
 
     public HotkeyBindingItem? SelectedHotkey
     {

--- a/src/SwfocTrainer.App/ViewModels/MainViewModelCoreStateBase.cs
+++ b/src/SwfocTrainer.App/ViewModels/MainViewModelCoreStateBase.cs
@@ -78,6 +78,7 @@ public abstract class MainViewModelCoreStateBase : INotifyPropertyChanged
     protected string _selectedActionId = string.Empty;
     protected string _payloadJson = MainViewModelDefaults.DefaultPayloadJsonTemplate;
     protected RuntimeMode _runtimeMode = RuntimeMode.Unknown;
+    protected string _runtimeModeOverride = MainViewModelRuntimeModeOverrideHelpers.ModeOverrideAuto;
     protected string _savePath = string.Empty;
     protected string _saveNodePath = string.Empty;
     protected string _saveEditValue = string.Empty;

--- a/src/SwfocTrainer.App/ViewModels/MainViewModelLiveOpsBase.cs
+++ b/src/SwfocTrainer.App/ViewModels/MainViewModelLiveOpsBase.cs
@@ -146,7 +146,7 @@ public abstract class MainViewModelLiveOpsBase : MainViewModelBindableMembersBas
             return;
         }
 
-        var result = await _selectedUnitTransactions.ApplyAsync(SelectedProfileId, draftResult.Draft!, RuntimeMode);
+        var result = await _selectedUnitTransactions.ApplyAsync(SelectedProfileId, draftResult.Draft!, EffectiveRuntimeMode);
         RefreshSelectedUnitTransactions();
         if (result.Succeeded)
         {
@@ -166,7 +166,7 @@ public abstract class MainViewModelLiveOpsBase : MainViewModelBindableMembersBas
             return;
         }
 
-        var result = await _selectedUnitTransactions.RevertLastAsync(SelectedProfileId, RuntimeMode);
+        var result = await _selectedUnitTransactions.RevertLastAsync(SelectedProfileId, EffectiveRuntimeMode);
         RefreshSelectedUnitTransactions();
         if (result.Succeeded)
         {
@@ -186,7 +186,7 @@ public abstract class MainViewModelLiveOpsBase : MainViewModelBindableMembersBas
             return;
         }
 
-        var result = await _selectedUnitTransactions.RestoreBaselineAsync(SelectedProfileId, RuntimeMode);
+        var result = await _selectedUnitTransactions.RestoreBaselineAsync(SelectedProfileId, EffectiveRuntimeMode);
         RefreshSelectedUnitTransactions();
         if (result.Succeeded)
         {
@@ -231,7 +231,7 @@ public abstract class MainViewModelLiveOpsBase : MainViewModelBindableMembersBas
             new MainViewModelSpawnHelpers.SpawnBatchInputRequest(
                 SelectedProfileId,
                 SelectedSpawnPreset,
-                RuntimeMode,
+                EffectiveRuntimeMode,
                 SpawnQuantity,
                 SpawnDelayMs));
         if (!batchInputs.Succeeded)
@@ -250,7 +250,7 @@ public abstract class MainViewModelLiveOpsBase : MainViewModelBindableMembersBas
             SelectedEntryMarker,
             SpawnStopOnFailure);
 
-        var result = await _spawnPresets.ExecuteBatchAsync(batchInputs.ProfileId, plan, RuntimeMode);
+        var result = await _spawnPresets.ExecuteBatchAsync(batchInputs.ProfileId, plan, EffectiveRuntimeMode);
         Status = result.Succeeded
             ? $"✓ {result.Message}"
             : $"✗ {result.Message}";
@@ -329,7 +329,9 @@ public abstract class MainViewModelLiveOpsBase : MainViewModelBindableMembersBas
         {
             ["reliabilityState"] = reliability?.State ?? UnknownValue,
             ["reliabilityReasonCode"] = reliability?.ReasonCode ?? UnknownValue,
-            ["bundleGateResult"] = MainViewModelDiagnostics.ResolveBundleGateResult(reliability, UnknownValue)
+            ["bundleGateResult"] = MainViewModelDiagnostics.ResolveBundleGateResult(reliability, UnknownValue),
+            ["runtimeModeHint"] = RuntimeMode.ToString(),
+            ["runtimeModeOverride"] = RuntimeModeOverride
         };
     }
 }

--- a/src/SwfocTrainer.App/ViewModels/MainViewModelQuickActionsBase.cs
+++ b/src/SwfocTrainer.App/ViewModels/MainViewModelQuickActionsBase.cs
@@ -48,7 +48,7 @@ public abstract class MainViewModelQuickActionsBase : MainViewModelLiveOpsBase
             SelectedProfileId!,
             actionId,
             payload,
-            RuntimeMode,
+            EffectiveRuntimeMode,
             BuildActionContext(actionId));
     }
 
@@ -151,7 +151,7 @@ public abstract class MainViewModelQuickActionsBase : MainViewModelLiveOpsBase
         SelectedProfileId!,
         ActionSetCredits,
         payload,
-        RuntimeMode,
+        EffectiveRuntimeMode,
         BuildActionContext(ActionSetCredits));
 
     protected Task QuickFreezeTimerAsync() => QuickRunActionAsync(
@@ -288,7 +288,7 @@ public abstract class MainViewModelQuickActionsBase : MainViewModelLiveOpsBase
             SelectedProfileId!,
             binding.ActionId,
             payloadNode,
-            RuntimeMode,
+            EffectiveRuntimeMode,
             BuildActionContext(binding.ActionId));
         Status = MainViewModelHotkeyHelpers.BuildHotkeyStatus(gesture, binding.ActionId, result);
 

--- a/src/SwfocTrainer.App/ViewModels/MainViewModelRuntimeModeOverrideHelpers.cs
+++ b/src/SwfocTrainer.App/ViewModels/MainViewModelRuntimeModeOverrideHelpers.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using SwfocTrainer.Core.IO;
+using SwfocTrainer.Core.Models;
+
+namespace SwfocTrainer.App.ViewModels;
+
+internal static class MainViewModelRuntimeModeOverrideHelpers
+{
+    internal const string ModeOverrideAuto = "Auto";
+    internal const string ModeOverrideGalactic = "Galactic";
+    internal const string ModeOverrideTactical = "Tactical";
+
+    private const string SettingsFileName = "runtime-mode-settings.json";
+    private const string SettingsKeyModeOverride = "modeOverride";
+
+    internal static readonly IReadOnlyList<string> ModeOverrideOptions =
+    [
+        ModeOverrideAuto,
+        ModeOverrideGalactic,
+        ModeOverrideTactical
+    ];
+
+    internal static string Normalize(string? raw)
+    {
+        if (string.Equals(raw, ModeOverrideGalactic, StringComparison.OrdinalIgnoreCase))
+        {
+            return ModeOverrideGalactic;
+        }
+
+        if (string.Equals(raw, ModeOverrideTactical, StringComparison.OrdinalIgnoreCase))
+        {
+            return ModeOverrideTactical;
+        }
+
+        return ModeOverrideAuto;
+    }
+
+    internal static RuntimeMode ResolveEffectiveRuntimeMode(RuntimeMode runtimeMode, string? modeOverride)
+    {
+        return Normalize(modeOverride) switch
+        {
+            ModeOverrideGalactic => RuntimeMode.Galactic,
+            ModeOverrideTactical => RuntimeMode.Tactical,
+            _ => runtimeMode
+        };
+    }
+
+    internal static string Load()
+    {
+        var path = GetSettingsPath();
+        if (!File.Exists(path))
+        {
+            return ModeOverrideAuto;
+        }
+
+        try
+        {
+            var json = File.ReadAllText(path);
+            var root = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+            return Normalize(root is not null && root.TryGetValue(SettingsKeyModeOverride, out var value) ? value : null);
+        }
+        catch
+        {
+            return ModeOverrideAuto;
+        }
+    }
+
+    internal static void Save(string? modeOverride)
+    {
+        var normalized = Normalize(modeOverride);
+        var path = GetSettingsPath();
+        TrustedPathPolicy.EnsureSubPath(TrustedPathPolicy.GetOrCreateAppDataRoot(), path);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var data = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [SettingsKeyModeOverride] = normalized
+        };
+
+        var json = JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(path, json);
+    }
+
+    private static string GetSettingsPath()
+    {
+        return Path.Combine(TrustedPathPolicy.GetOrCreateAppDataRoot(), SettingsFileName);
+    }
+}

--- a/tests/SwfocTrainer.Tests/App/MainViewModelRuntimeModeOverrideTests.cs
+++ b/tests/SwfocTrainer.Tests/App/MainViewModelRuntimeModeOverrideTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using SwfocTrainer.App.Models;
+using SwfocTrainer.App.ViewModels;
+using SwfocTrainer.Core.Models;
+using Xunit;
+
+namespace SwfocTrainer.Tests.App;
+
+public sealed class MainViewModelRuntimeModeOverrideTests
+{
+    [Fact]
+    public void TryBuildBatchInputs_ShouldBlock_WhenModeUnknownWithoutOverride()
+    {
+        var result = MainViewModelSpawnHelpers.TryBuildBatchInputs(
+            new MainViewModelSpawnHelpers.SpawnBatchInputRequest(
+                SelectedProfileId: "base_swfoc",
+                SelectedSpawnPreset: BuildPreset(),
+                RuntimeMode: RuntimeMode.Unknown,
+                SpawnQuantity: "1",
+                SpawnDelayMs: "125"));
+
+        result.Succeeded.Should().BeFalse();
+        result.FailureStatus.Should().Contain("runtime mode is unknown");
+    }
+
+    [Fact]
+    public void TryBuildBatchInputs_ShouldAllow_WhenModeOverriddenToTactical()
+    {
+        var effectiveMode = MainViewModelRuntimeModeOverrideHelpers.ResolveEffectiveRuntimeMode(RuntimeMode.Unknown, "Tactical");
+        var result = MainViewModelSpawnHelpers.TryBuildBatchInputs(
+            new MainViewModelSpawnHelpers.SpawnBatchInputRequest(
+                SelectedProfileId: "base_swfoc",
+                SelectedSpawnPreset: BuildPreset(),
+                RuntimeMode: effectiveMode,
+                SpawnQuantity: "1",
+                SpawnDelayMs: "125"));
+
+        result.Succeeded.Should().BeTrue();
+        result.FailureStatus.Should().BeEmpty();
+    }
+
+    private static SpawnPresetViewItem BuildPreset() => new(
+        "test",
+        "Test",
+        "stormtrooper_squad",
+        "EMPIRE",
+        "AUTO",
+        1,
+        125,
+        "");
+}

--- a/tests/SwfocTrainer.Tests/Runtime/RuntimeAdapterModeOverrideTests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/RuntimeAdapterModeOverrideTests.cs
@@ -1,0 +1,116 @@
+using System.Reflection;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using SwfocTrainer.Core.Contracts;
+using SwfocTrainer.Core.Models;
+using SwfocTrainer.Runtime.Services;
+using Xunit;
+
+namespace SwfocTrainer.Tests.Runtime;
+
+public sealed class RuntimeAdapterModeOverrideTests
+{
+    [Fact]
+    public void ResolveEffectiveMode_ShouldUseManualOverride_WhenOverrideProvided()
+    {
+        var adapter = CreateAdapter();
+        var request = new ActionExecutionRequest(
+            BuildAction(),
+            new JsonObject(),
+            "test_profile",
+            RuntimeMode.Galactic,
+            new Dictionary<string, object?>
+            {
+                ["runtimeModeOverride"] = "Tactical"
+            });
+
+        var resolved = InvokeResolveEffectiveMode(adapter, request);
+
+        resolved.Request.RuntimeMode.Should().Be(RuntimeMode.Tactical);
+        resolved.Diagnostics["runtimeModeHint"].Should().Be("Galactic");
+        resolved.Diagnostics["runtimeModeProbe"].Should().Be("Unknown");
+        resolved.Diagnostics["runtimeModeEffective"].Should().Be("Tactical");
+        resolved.Diagnostics["runtimeModeEffectiveSource"].Should().Be("manual_override");
+    }
+
+    [Fact]
+    public void ResolveEffectiveMode_ShouldRemainAuto_WhenOverrideIsAuto()
+    {
+        var adapter = CreateAdapter();
+        var request = new ActionExecutionRequest(
+            BuildAction(),
+            new JsonObject(),
+            "test_profile",
+            RuntimeMode.Galactic,
+            new Dictionary<string, object?>
+            {
+                ["runtimeModeOverride"] = "Auto"
+            });
+
+        var resolved = InvokeResolveEffectiveMode(adapter, request);
+
+        resolved.Request.RuntimeMode.Should().Be(RuntimeMode.Galactic);
+        resolved.Diagnostics["runtimeModeEffectiveSource"].Should().Be("auto");
+    }
+
+    private static (ActionExecutionRequest Request, IReadOnlyDictionary<string, object?> Diagnostics) InvokeResolveEffectiveMode(RuntimeAdapter adapter, ActionExecutionRequest request)
+    {
+        var method = typeof(RuntimeAdapter).GetMethod("ResolveEffectiveMode", BindingFlags.NonPublic | BindingFlags.Instance);
+        method.Should().NotBeNull();
+        var tuple = method!.Invoke(adapter, new object?[] { request });
+        tuple.Should().NotBeNull();
+        return ((ActionExecutionRequest Request, IReadOnlyDictionary<string, object?> Diagnostics))tuple!;
+    }
+
+    private static RuntimeAdapter CreateAdapter()
+    {
+        return new RuntimeAdapter(
+            new StubProcessLocator(),
+            new StubProfileRepository(),
+            new StubSignatureResolver(),
+            NullLogger<RuntimeAdapter>.Instance);
+    }
+
+    private static ActionSpec BuildAction() => new(
+        "test_action",
+        ActionCategory.Global,
+        RuntimeMode.Unknown,
+        ExecutionKind.Memory,
+        new JsonObject(),
+        VerifyReadback: false,
+        CooldownMs: 0);
+
+    private sealed class StubProcessLocator : IProcessLocator
+    {
+        public Task<IReadOnlyList<ProcessMetadata>> FindSupportedProcessesAsync(CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyList<ProcessMetadata>>(Array.Empty<ProcessMetadata>());
+
+        public Task<ProcessMetadata?> FindBestMatchAsync(ExeTarget target, CancellationToken cancellationToken)
+            => Task.FromResult<ProcessMetadata?>(null);
+    }
+
+    private sealed class StubProfileRepository : IProfileRepository
+    {
+        public Task<ProfileManifest> LoadManifestAsync(CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<TrainerProfile> LoadProfileAsync(string profileId, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<TrainerProfile> ResolveInheritedProfileAsync(string profileId, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task ValidateProfileAsync(TrainerProfile profile, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<IReadOnlyList<string>> ListAvailableProfilesAsync(CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+    }
+
+    private sealed class StubSignatureResolver : ISignatureResolver
+    {
+        public Task<SymbolMap> ResolveAsync(ProfileBuild build, IReadOnlyList<SignatureSet> signatureSets, IReadOnlyDictionary<string, long> fallbackOffsets, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a deterministic manual override for effective runtime mode when live transitions are not reliably detectable so users can force `Galactic`/`Tactical` behavior or continue using `Auto` discovery.
- Ensure mode selection is visible in the UI and that runtime gating/validation uses the effective mode (hint/probe/override) to avoid unexpected blocked actions.
- Preserve existing diagnostics and reason-code visibility so operators can audit why a mode was chosen and which source produced the effective mode. Affects all profiles (`base`, `aotr`, `roe`, `custom`).

### Description
- UI: added a small mode override control and effective-mode display to `src/SwfocTrainer.App/MainWindow.xaml` (`Auto`, `Galactic`, `Tactical`).
- ViewModel & persistence: added `RuntimeModeOverride`, `EffectiveRuntimeMode` and `RuntimeModeOverrideOptions` plus persisted settings via `src/SwfocTrainer.App/ViewModels/MainViewModelRuntimeModeOverrideHelpers.cs` and wired load/save in `MainViewModel`.
- App wiring: changed action execution and live-ops calls to use `EffectiveRuntimeMode` and included `runtimeModeHint` / `runtimeModeOverride` in action context diagnostics (`MainViewModel`, `MainViewModelLiveOpsBase`, `MainViewModelQuickActionsBase`, `MainViewModelSpawnHelpers`).
- Runtime: in `src/SwfocTrainer.Runtime/Services/RuntimeAdapter.cs` resolve an effective mode before gating and routing (apply manual override when present, otherwise use hint/probe fallback); emit diagnostics keys `runtimeModeHint`, `runtimeModeProbe`, `runtimeModeEffective`, and `runtimeModeEffectiveSource` (values: `auto` | `manual_override`) and merge them into action result diagnostics on all return paths.
- Tests: added deterministic unit tests covering resolution and app gating semantics: `tests/SwfocTrainer.Tests/Runtime/RuntimeAdapterModeOverrideTests.cs` and `tests/SwfocTrainer.Tests/App/MainViewModelRuntimeModeOverrideTests.cs`.
- Compatibility/note: added `InternalsVisibleTo("SwfocTrainer.Tests")` for app assembly to allow internal helper tests.

### Testing
- New deterministic tests added: `RuntimeAdapterModeOverrideTests` and `MainViewModelRuntimeModeOverrideTests` (cover manual override resolution and spawn-batch gating under override vs unknown).
- Attempted to run targeted tests with `dotnet test` but the environment reported `dotnet: command not found` so tests were not executed here; the added tests are committed and should be run in CI or a dev machine via:
  - `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --filter "FullyQualifiedName~MainViewModelRuntimeModeOverrideTests|FullyQualifiedName~RuntimeAdapterModeOverrideTests|FullyQualifiedName~RuntimeAdapterRouteDiagnosticsTests|FullyQualifiedName~RuntimeModeProbeResolverTests"`
  - canonical verification: `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --no-build --filter "FullyQualifiedName!~SwfocTrainer.Tests.Profiles.Live&FullyQualifiedName!~RuntimeAttachSmokeTests"`
- Status in this environment: tests were not run due to missing .NET SDK (`dotnet` not found). Please run the commands above in CI or locally; tests are deterministic and target-only non-live logic.

Risk: risk:medium — runtime action gating is influenced by the override and new diagnostics are emitted; change is additive and reversible by reverting this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a258a0eddc8332a0e1d453872be554)