### PR TITLE
[codex] Push-and-green functional closure finalization

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -106,6 +106,18 @@ Reliability rule for runtime/mod tasks:
   evidence: manual `2026-02-28` `pwsh ./tools/lua-harness/run-lua-harness.ps1 -Strict`
   evidence: bundle `TestResults/runs/20260228-171028/repro-bundle.json` (`classification=blocked_environment`)
   evidence: bundle `TestResults/runs/20260228-171159/repro-bundle.json` (`classification=blocked_environment`)
+- [x] Functional closure wave: deterministic native host bootstrap, promoted `set_unit_cap` enable->disable matrix semantics, helper forced-profile fallback diagnostics, and Codex-launched live process matrix (EAW + SWFOC tactical + AOTR + ROE) with strict bundle validation.
+  evidence: test `tests/SwfocTrainer.Tests/Runtime/ProcessLocatorForcedContextTests.cs`
+  evidence: test `tests/SwfocTrainer.Tests/Profiles/LivePromotedActionMatrixTests.cs`
+  evidence: test `tests/SwfocTrainer.Tests/Profiles/LiveHeroHelperWorkflowTests.cs`
+  evidence: manual `2026-02-28` `dotnet build SwfocTrainer.sln -c Release --no-restore` => `Build succeeded`
+  evidence: manual `2026-02-28` `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --no-build --filter "FullyQualifiedName!~SwfocTrainer.Tests.Profiles.Live&FullyQualifiedName!~RuntimeAttachSmokeTests"` => `Passed: 192`
+  evidence: manual `2026-02-28` `powershell.exe -File tools/validate-workshop-topmods.ps1 -Path tools/fixtures/workshop_topmods_sample.json -Strict` => `validation passed`
+  evidence: manual `2026-02-28` `powershell.exe -File tools/validate-generated-profile-seed.ps1 -Path tools/fixtures/generated_profile_seeds_sample.json -Strict` => `validation passed`
+  evidence: manual `2026-02-28` Session A EAW snapshot `TestResults/runs/LIVE-EAW-20260228-204540/eaw-process-snapshot.json`
+  evidence: bundle `TestResults/runs/LIVE-TACTICAL-20260228-211256/repro-bundle.json`
+  evidence: bundle `TestResults/runs/LIVE-AOTR-20260228-211521/repro-bundle.json`
+  evidence: bundle `TestResults/runs/LIVE-ROE-20260228-211757/repro-bundle.json`
 
 ## Later (M2 + M3 + M4)
 

--- a/docs/LIVE_VALIDATION_RUNBOOK.md
+++ b/docs/LIVE_VALIDATION_RUNBOOK.md
@@ -5,8 +5,10 @@ Use this runbook to gather real-machine evidence for runtime/mod issues and mile
 ## 1. Preconditions
 
 - Launch the target game session first (`swfoc.exe` / `StarWarsG.exe`).
-- Ensure extender bridge host is running for extender-routed credits checks:
-  - `SwfocExtender.Host` on pipe `SwfocExtenderBridge`.
+- `tools/run-live-validation.ps1` preflights native host build and wires:
+  - `native/runtime/SwfocExtender.Host.exe`
+  - `SWFOC_EXTENDER_HOST_PATH` for every `dotnet test` subprocess.
+- If running a live test command manually (outside run-live script), set `SWFOC_EXTENDER_HOST_PATH` explicitly to avoid nondeterministic host resolution.
 - Promoted actions are extender-authoritative and fail-closed:
   - no managed/memory fallback is accepted for promoted matrix evidence.
   - missing or unverified promoted capability must surface fail-closed diagnostics.
@@ -166,6 +168,13 @@ Expected evidence behavior for promoted actions:
 - `hasFallbackMarker=false`
 - fail-closed outcomes use explicit route diagnostics (`SAFETY_FAIL_CLOSED`) and block issue `#7` closure.
 
+`set_unit_cap` promoted matrix contract:
+
+- run as a deterministic two-step sequence per profile:
+  1. enable (`enable=true`, snapshot/capture)
+  2. disable (`enable=false`, restore)
+- disable-first behavior is intentionally fail-closed and must not be asserted as pass in matrix evidence.
+
 ## 5. Bundle Validation
 
 ```powershell
@@ -202,8 +211,8 @@ Close issues only when all required evidence is present:
 Issue `#7` evidence decision gate:
 
 - `actionStatusDiagnostics.status` is `captured`.
-- `actionStatusDiagnostics.summary.total=15`, `passed=15`, `failed=0`, `skipped=0`.
-- every matrix entry for the five promoted actions across `base_swfoc`, `aotr_1397421866_swfoc`, and `roe_3447786229_swfoc` is present.
+- `actionStatusDiagnostics.summary.total=18`, `passed=18`, `failed=0`, `skipped=0` for full-context closure runs.
+- every matrix entry for the promoted actions across `base_swfoc`, `aotr_1397421866_swfoc`, and `roe_3447786229_swfoc` is present, including `set_unit_cap[1/2]` and `set_unit_cap[2/2]` per profile.
 - no matrix entry includes fallback markers or blocked diagnostics (`hasFallbackMarker=true`, `backendRoute` not `Extender`, or non-pass route/probe reason codes).
 - top-mod rows (when present) must never be silent omissions; each row must be explicit `Passed`, `Failed`, or `Skipped` with `skipReasonCode` when skipped.
 

--- a/tests/SwfocTrainer.Tests/Runtime/ProcessLocatorForcedContextTests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/ProcessLocatorForcedContextTests.cs
@@ -1,0 +1,108 @@
+using System.Reflection;
+using FluentAssertions;
+using SwfocTrainer.Core.Models;
+using SwfocTrainer.Runtime.Services;
+using Xunit;
+
+namespace SwfocTrainer.Tests.Runtime;
+
+public sealed class ProcessLocatorForcedContextTests
+{
+    [Fact]
+    public void ResolveForcedContext_Should_Return_Forced_When_NoMarkers_And_ForcedHintsPresent()
+    {
+        var resolution = InvokeResolveForcedContext(
+            commandLine: "StarWarsG.exe NOARTPROCESS IGNOREASSERTS",
+            modPathRaw: null,
+            detectedSteamModIds: Array.Empty<string>(),
+            options: new ProcessLocatorOptions(
+                ForcedWorkshopIds: new[] { "3447786229", "1397421866" },
+                ForcedProfileId: "roe_3447786229_swfoc"));
+
+        ReadStringProperty(resolution, "Source").Should().Be("forced");
+        ReadStringProperty(resolution, "ForcedWorkshopIdsCsv").Should().Be("1397421866,3447786229");
+        ReadStringProperty(resolution, "ForcedProfileId").Should().Be("roe_3447786229_swfoc");
+        ReadStringSequenceProperty(resolution, "EffectiveSteamModIds")
+            .Should()
+            .Equal("1397421866", "3447786229");
+    }
+
+    [Fact]
+    public void ResolveForcedContext_Should_Stay_Detected_When_ModMarkers_Are_Present()
+    {
+        var resolution = InvokeResolveForcedContext(
+            commandLine: "\"C:\\Game\\corruption\\StarWarsG.exe\" STEAMMOD=1397421866",
+            modPathRaw: null,
+            detectedSteamModIds: new[] { "1397421866" },
+            options: new ProcessLocatorOptions(
+                ForcedWorkshopIds: new[] { "3447786229" },
+                ForcedProfileId: "roe_3447786229_swfoc"));
+
+        ReadStringProperty(resolution, "Source").Should().Be("detected");
+        ReadStringProperty(resolution, "ForcedWorkshopIdsCsv").Should().BeEmpty();
+        ReadStringProperty(resolution, "ForcedProfileId").Should().BeNull();
+        ReadStringSequenceProperty(resolution, "EffectiveSteamModIds")
+            .Should()
+            .Equal("1397421866");
+    }
+
+    [Fact]
+    public void ResolveOptionsFromEnvironment_Should_Parse_Forced_Ids_And_Profile()
+    {
+        var previousWorkshopIds = Environment.GetEnvironmentVariable(ProcessLocator.ForceWorkshopIdsEnvVar);
+        var previousProfileId = Environment.GetEnvironmentVariable(ProcessLocator.ForceProfileIdEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(ProcessLocator.ForceWorkshopIdsEnvVar, "3447786229,1397421866,3447786229");
+            Environment.SetEnvironmentVariable(ProcessLocator.ForceProfileIdEnvVar, " roe_3447786229_swfoc ");
+
+            var options = InvokeResolveOptionsFromEnvironment();
+
+            options.ForcedWorkshopIds.Should().Equal("1397421866", "3447786229");
+            options.ForcedProfileId.Should().Be("roe_3447786229_swfoc");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(ProcessLocator.ForceWorkshopIdsEnvVar, previousWorkshopIds);
+            Environment.SetEnvironmentVariable(ProcessLocator.ForceProfileIdEnvVar, previousProfileId);
+        }
+    }
+
+    private static object InvokeResolveForcedContext(
+        string? commandLine,
+        string? modPathRaw,
+        IReadOnlyList<string> detectedSteamModIds,
+        ProcessLocatorOptions options)
+    {
+        var method = typeof(ProcessLocator).GetMethod("ResolveForcedContext", BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull();
+        var result = method!.Invoke(null, new object?[] { commandLine, modPathRaw, detectedSteamModIds, options });
+        result.Should().NotBeNull();
+        return result!;
+    }
+
+    private static ProcessLocatorOptions InvokeResolveOptionsFromEnvironment()
+    {
+        var method = typeof(ProcessLocator).GetMethod("ResolveOptionsFromEnvironment", BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull();
+        var result = method!.Invoke(null, Array.Empty<object>());
+        result.Should().NotBeNull();
+        return result!.Should().BeAssignableTo<ProcessLocatorOptions>().Subject;
+    }
+
+    private static string? ReadStringProperty(object instance, string propertyName)
+    {
+        var property = instance.GetType().GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+        property.Should().NotBeNull($"property '{propertyName}' should exist on forced context resolution payload.");
+        return property!.GetValue(instance) as string;
+    }
+
+    private static IReadOnlyList<string> ReadStringSequenceProperty(object instance, string propertyName)
+    {
+        var property = instance.GetType().GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+        property.Should().NotBeNull($"property '{propertyName}' should exist on forced context resolution payload.");
+        var value = property!.GetValue(instance);
+        value.Should().BeAssignableTo<IEnumerable<string>>();
+        return value!.Should().BeAssignableTo<IEnumerable<string>>().Subject.ToArray();
+    }
+}

--- a/tools/native/build-native.ps1
+++ b/tools/native/build-native.ps1
@@ -30,6 +30,68 @@ function Get-LastExitCodeOrZero {
     return 0
 }
 
+function Resolve-ProviderAbsolutePath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "Path cannot be empty."
+    }
+
+    $candidate = if ([System.IO.Path]::IsPathRooted($Path)) {
+        $Path
+    }
+    else {
+        Join-Path (Get-Location) $Path
+    }
+
+    return [System.IO.Path]::GetFullPath($candidate)
+}
+
+function Resolve-HostArtifact {
+    param(
+        [Parameter(Mandatory = $true)][string]$OutDir,
+        [Parameter(Mandatory = $true)][string]$Config
+    )
+
+    $searchCount = 0
+    $expectedArtifacts = @(
+        (Join-Path $OutDir "SwfocExtender.Bridge\\$Config\\SwfocExtender.Host.exe"),
+        (Join-Path $OutDir "SwfocExtender.Bridge\\SwfocExtender.Host.exe"),
+        (Join-Path $OutDir "SwfocExtender.Bridge\\x64\\$Config\\SwfocExtender.Host.exe"),
+        (Join-Path $OutDir "x64\\$Config\\SwfocExtender.Host.exe"),
+        (Join-Path $OutDir "$Config\\SwfocExtender.Host.exe"),
+        (Join-Path $OutDir "SwfocExtender.Host.exe")
+    )
+
+    foreach ($path in $expectedArtifacts) {
+        $searchCount += 1
+        if (Test-Path -Path $path) {
+            return [PSCustomObject]@{
+                Path = $path
+                SearchCount = $searchCount
+                Source = "expected_path"
+            }
+        }
+    }
+
+    $recursiveHits = @(Get-ChildItem -Path $OutDir -Filter "SwfocExtender.Host.exe" -File -Recurse -ErrorAction SilentlyContinue)
+    $searchCount += $recursiveHits.Count
+    $recursiveArtifact = $recursiveHits | Select-Object -ExpandProperty FullName -First 1
+    if (-not [string]::IsNullOrWhiteSpace($recursiveArtifact)) {
+        return [PSCustomObject]@{
+            Path = $recursiveArtifact
+            SearchCount = $searchCount
+            Source = "recursive_scan"
+        }
+    }
+
+    return [PSCustomObject]@{
+        Path = $null
+        SearchCount = $searchCount
+        Source = "not_found"
+    }
+}
+
 function Resolve-WindowsGeneratorPlan {
     param(
         [string]$Configuration,
@@ -81,15 +143,18 @@ function Invoke-WindowsBuild {
         throw "cmake --version failed for '$CmakePath'."
     }
 
+    $resolvedOutDir = Resolve-ProviderAbsolutePath -Path $OutDir
     $generatorPlan = Resolve-WindowsGeneratorPlan `
         -Configuration $Config `
         -RecommendedGenerator $RecommendedGenerator `
         -VsInstancePath $VsInstancePath
 
     $expectedGenerator = [string]$generatorPlan.Name
-    $configureArgs = @("-S", "native", "-B", $OutDir)
+    $configureArgs = @("-S", "native", "-B", $resolvedOutDir)
     $configureArgs += @($generatorPlan.Args)
     Write-Output "Windows native configure generator: $expectedGenerator"
+    Write-Output "resolvedBuildDir: $resolvedOutDir"
+    Write-Output "target: SwfocExtender.Host"
     if (-not [string]::IsNullOrWhiteSpace($VsProductLineVersion)) {
         Write-Output "Visual Studio product line: $VsProductLineVersion"
     }
@@ -97,15 +162,15 @@ function Invoke-WindowsBuild {
         Write-Output "Visual Studio instance: $VsInstancePath"
     }
 
-    $cachePath = Join-Path $OutDir "CMakeCache.txt"
+    $cachePath = Join-Path $resolvedOutDir "CMakeCache.txt"
     if (Test-Path -Path $cachePath) {
         $cacheLine = Select-String -Path $cachePath -Pattern '^CMAKE_GENERATOR:INTERNAL=(.+)$' | Select-Object -First 1
         if ($null -ne $cacheLine) {
             $cachedGenerator = $cacheLine.Matches[0].Groups[1].Value
             if (-not [string]::Equals($cachedGenerator, $expectedGenerator, [System.StringComparison]::OrdinalIgnoreCase)) {
-                Write-Warning "CMake generator changed from '$cachedGenerator' to '$expectedGenerator'; clearing stale cache in '$OutDir'."
+                Write-Warning "CMake generator changed from '$cachedGenerator' to '$expectedGenerator'; clearing stale cache in '$resolvedOutDir'."
                 Remove-Item -Path $cachePath -Force -ErrorAction SilentlyContinue
-                Remove-Item -Path (Join-Path $OutDir "CMakeFiles") -Recurse -Force -ErrorAction SilentlyContinue
+                Remove-Item -Path (Join-Path $resolvedOutDir "CMakeFiles") -Recurse -Force -ErrorAction SilentlyContinue
             }
         }
     }
@@ -115,7 +180,7 @@ function Invoke-WindowsBuild {
         throw "native configure failed for Windows mode."
     }
 
-    $buildArgs = @("--build", $OutDir, "--target", "SwfocExtender.Host")
+    $buildArgs = @("--build", $resolvedOutDir, "--target", "SwfocExtender.Host")
     if ([bool]$generatorPlan.UsesMultiConfig) {
         $buildArgs += @("--config", $Config)
     }
@@ -125,27 +190,31 @@ function Invoke-WindowsBuild {
         throw "native build failed for Windows mode."
     }
 
-    $expectedArtifacts = @(
-        (Join-Path $OutDir "SwfocExtender.Bridge\\$Config\\SwfocExtender.Host.exe"),
-        (Join-Path $OutDir "SwfocExtender.Bridge\\SwfocExtender.Host.exe"),
-        (Join-Path $OutDir "SwfocExtender.Bridge\\x64\\$Config\\SwfocExtender.Host.exe"),
-        (Join-Path $OutDir "x64\\$Config\\SwfocExtender.Host.exe"),
-        (Join-Path $OutDir "$Config\\SwfocExtender.Host.exe"),
-        (Join-Path $OutDir "SwfocExtender.Host.exe")
-    )
+    $artifactResolution = Resolve-HostArtifact -OutDir $resolvedOutDir -Config $Config
+    if ([string]::IsNullOrWhiteSpace($artifactResolution.Path)) {
+        Write-Warning "Host artifact not found on first scan; retrying target build with verbose output."
+        $fallbackBuildArgs = @("--build", $resolvedOutDir, "--target", "SwfocExtender.Host", "--verbose")
+        if ([bool]$generatorPlan.UsesMultiConfig) {
+            $fallbackBuildArgs += @("--config", $Config)
+        }
 
-    $artifact = $expectedArtifacts | Where-Object { Test-Path -Path $_ } | Select-Object -First 1
-    if ($null -eq $artifact) {
-        # VS/CMake layout can vary across major versions; keep hard assertion but allow deterministic recursive discovery.
-        $artifact = Get-ChildItem -Path $OutDir -Filter "SwfocExtender.Host.exe" -File -Recurse -ErrorAction SilentlyContinue |
-            Select-Object -ExpandProperty FullName -First 1
+        & $CmakePath @fallbackBuildArgs
+        if ((Get-LastExitCodeOrZero) -ne 0) {
+            throw "native fallback build failed for Windows mode."
+        }
+
+        $artifactResolution = Resolve-HostArtifact -OutDir $resolvedOutDir -Config $Config
     }
 
-    if ($null -eq $artifact) {
-        throw "native build completed but SwfocExtender.Host.exe artifact was not found under '$OutDir'."
+    $artifact = [string]$artifactResolution.Path
+    if ([string]::IsNullOrWhiteSpace($artifact)) {
+        throw "native build completed but SwfocExtender.Host.exe artifact was not found under '$resolvedOutDir'."
     }
 
     Write-Output "Windows host artifact: $artifact"
+    Write-Output "artifactSearchCount: $($artifactResolution.SearchCount)"
+    Write-Output "artifactResolvedPath: $artifact"
+    Write-Output "artifactResolutionSource: $($artifactResolution.Source)"
 
     $runtimeDir = Join-Path $repoRoot "native/runtime"
     if (-not (Test-Path -Path $runtimeDir)) {


### PR DESCRIPTION
## Summary
This PR finalizes the push-and-green closure wave on `codex/m1-epic7-closure-phase` with a single commit and updated evidence references.

Key delivered changes:
- Hardened native host bootstrap and artifact resolution in `tools/native/build-native.ps1` (absolute path normalization, deterministic re-scan, second-pass target build, explicit diagnostics).
- Wired `SWFOC_EXTENDER_HOST_PATH` deterministically in `tools/run-live-validation.ps1` for each live test invocation.
- Upgraded Python fallback handling for tooling/bundle scripts (`run-live-validation.ps1`, `collect-mod-repro-bundle.ps1`) with captured execution flow.
- Aligned promoted matrix semantics for `set_unit_cap` to explicit two-step fail-closed contract (`enable=true`, then `enable=false`).
- Added helper forced-profile fallback diagnostics and deterministic ProcessLocator forced-context tests.
- Synced runbook and board evidence links for final live matrix runs.

## Why
Latest closure effort had non-deterministic host/bootstrap and context/tooling edge behavior during live evidence runs. This PR makes those behaviors deterministic and aligns live matrix expectations with fail-closed runtime safety semantics.

## Risk
- `risk:high` (runtime/tooling integration path touching native host and live validation harness).
- No fail-open behavior introduced.
- Protected merge workflow retained (no direct push to `main`).

## Evidence (Deterministic)
- `dotnet build SwfocTrainer.sln -c Release --no-restore` ✅
- `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --no-build --filter "FullyQualifiedName!~SwfocTrainer.Tests.Profiles.Live&FullyQualifiedName!~RuntimeAttachSmokeTests"` ✅ (`Passed: 192, Failed: 0`)
- `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File ./tools/validate-workshop-topmods.ps1 -Path tools/fixtures/workshop_topmods_sample.json -Strict` ✅
- `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File ./tools/validate-generated-profile-seed.ps1 -Path tools/fixtures/generated_profile_seeds_sample.json -Strict` ✅

## Evidence (Live / Bundles)
- Session A snapshot:
  - `TestResults/runs/LIVE-EAW-20260228-204540/eaw-process-snapshot.json`
- Session B Tactical bundle:
  - `TestResults/runs/LIVE-TACTICAL-20260228-211256/repro-bundle.json`
- Session C AOTR bundle:
  - `TestResults/runs/LIVE-AOTR-20260228-211521/repro-bundle.json`
- Session D ROE bundle:
  - `TestResults/runs/LIVE-ROE-20260228-211757/repro-bundle.json`
- Consolidated matrix:
  - `TestResults/runs/LIVE-MATRIX-20260228-211757.md`

Bundle strict schema validation commands all passed:
- `... LIVE-TACTICAL-20260228-211256/repro-bundle.json`
- `... LIVE-AOTR-20260228-211521/repro-bundle.json`
- `... LIVE-ROE-20260228-211757/repro-bundle.json`

## Behavioral Notes
- Promoted matrix now records `set_unit_cap[1/2]` and `set_unit_cap[2/2]` per profile when context is available.
- Forced context remains evidence routing only and does not bypass runtime mutation safety checks.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated validation runbook with clarified preflight procedures and bundle validation requirements.

* **Tests**
  * Added comprehensive test coverage for helper profile selection, promoted action matrix execution, and forced context resolution.

* **Chores**
  * Enhanced build and validation tooling with improved cross-platform Python resolution, native host artifact detection, and diagnostic output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Reliability Evidence Contract
Repro bundle json: TestResults/runs/LIVE-ROE-20260228-211757/repro-bundle.json
Classification: passed
