### PR TITLE
[codex] Delta closure: truthful routing + portability cleanup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -118,6 +118,13 @@ Reliability rule for runtime/mod tasks:
   evidence: bundle `TestResults/runs/LIVE-TACTICAL-20260228-211256/repro-bundle.json`
   evidence: bundle `TestResults/runs/LIVE-AOTR-20260228-211521/repro-bundle.json`
   evidence: bundle `TestResults/runs/LIVE-ROE-20260228-211757/repro-bundle.json`
+- [x] Delta closure wave: default non-forced promoted FoC routing + env override (`SWFOC_FORCE_PROMOTED_EXTENDER`), `universal_auto` backend de-trap (`auto`), and profile metadata save-root portability cleanup.
+  evidence: test `tests/SwfocTrainer.Tests/Runtime/BackendRouterTests.cs`
+  evidence: test `tests/SwfocTrainer.Tests/Profiles/ProfileInheritanceTests.cs`
+  evidence: test `tests/SwfocTrainer.Tests/Profiles/ProfileMetadataPortabilityTests.cs`
+  evidence: manual `2026-03-01` `dotnet restore SwfocTrainer.sln` + `dotnet build SwfocTrainer.sln -c Release --no-restore` + `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --no-build --filter "FullyQualifiedName!~SwfocTrainer.Tests.Profiles.Live&FullyQualifiedName!~RuntimeAttachSmokeTests"` => `Passed: 233`
+  evidence: bundle `TestResults/runs/20260301-004145/repro-bundle.json` (`classification=blocked_environment`, tactical default routing run; no swfoc process detected)
+  evidence: bundle `TestResults/runs/20260301-004232/repro-bundle.json` (`classification=blocked_environment`, tactical forced-override run; no swfoc process detected)
 
 ## Later (M2 + M3 + M4)
 

--- a/docs/LIVE_VALIDATION_RUNBOOK.md
+++ b/docs/LIVE_VALIDATION_RUNBOOK.md
@@ -9,9 +9,11 @@ Use this runbook to gather real-machine evidence for runtime/mod issues and mile
   - `native/runtime/SwfocExtender.Host.exe`
   - `SWFOC_EXTENDER_HOST_PATH` for every `dotnet test` subprocess.
 - If running a live test command manually (outside run-live script), set `SWFOC_EXTENDER_HOST_PATH` explicitly to avoid nondeterministic host resolution.
-- Promoted actions are extender-authoritative and fail-closed:
-  - no managed/memory fallback is accepted for promoted matrix evidence.
-  - missing or unverified promoted capability must surface fail-closed diagnostics.
+- Save-root defaults are runtime-resolved from current user environment (`SaveOptions.DefaultSaveRootPath`); no profile should hardcode per-user save paths.
+- Promoted FoC actions default to non-forced routing:
+  - `SWFOC_FORCE_PROMOTED_EXTENDER` unset/false keeps normal execution-kind routing.
+  - set `SWFOC_FORCE_PROMOTED_EXTENDER=1` when running extender-authoritative promoted matrix evidence.
+  - missing or unverified promoted capability under forced mode must surface fail-closed diagnostics.
 - For AOTR: ensure launch context resolves to `aotr_1397421866_swfoc`.
 - For ROE: ensure launch context resolves to `roe_3447786229_swfoc`.
 - From repo root, run on Windows PowerShell.
@@ -139,6 +141,12 @@ vNext bundle sections (required for runtime-affecting changes):
 
 ## 4. Promoted Action Matrix Evidence (Issue #7)
 
+Set extender-forced routing before promoted matrix closure runs:
+
+```powershell
+$env:SWFOC_FORCE_PROMOTED_EXTENDER = "1"
+```
+
 Promoted matrix evidence must cover 3 profiles x 5 actions (15 total checks):
 
 | Action ID | `base_swfoc` | `aotr_1397421866_swfoc` | `roe_3447786229_swfoc` |
@@ -167,6 +175,12 @@ Expected evidence behavior for promoted actions:
 - `hybridExecution=false`
 - `hasFallbackMarker=false`
 - fail-closed outcomes use explicit route diagnostics (`SAFETY_FAIL_CLOSED`) and block issue `#7` closure.
+
+Reset the override after matrix runs:
+
+```powershell
+Remove-Item Env:SWFOC_FORCE_PROMOTED_EXTENDER -ErrorAction SilentlyContinue
+```
 
 `set_unit_cap` promoted matrix contract:
 

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -69,7 +69,8 @@
   - verifies feature-flag gate, missing runtime context gate, and mode mismatch blocking
 - `BackendRouterTests`
   - verifies fail-closed mutating behavior for hard-extender profiles
-  - verifies extender route promotion only when capability proof is present
+  - verifies promoted extender routing is opt-in via `SWFOC_FORCE_PROMOTED_EXTENDER`
+  - verifies extender route promotion only when capability proof is present under override mode
   - verifies capability contract blocking and legacy memory fallback behavior
   - verifies fallback patch actions stay off promoted extender matrix and preserve managed-memory routing
 - `MainViewModelSessionGatingTests`
@@ -193,7 +194,13 @@ For each profile (`base_sweaw`, `base_swfoc`, `aotr_1397421866_swfoc`, `roe_3447
 
 ## Phase 2 promoted action and hotkey checks
 
-Promoted actions are extender-authoritative and fail-closed for FoC profiles.
+Promoted FoC actions are not forced to extender by default.
+For extender-authoritative promoted matrix evidence, explicitly enable:
+
+```powershell
+$env:SWFOC_FORCE_PROMOTED_EXTENDER = "1"
+```
+
 Evidence must come from `actionStatusDiagnostics` in `repro-bundle.json` (source `live-promoted-action-matrix.json`).
 
 Required profile/action matrix:
@@ -225,6 +232,12 @@ Verification checklist:
 6. Verify top-mod evidence extension:
    - when `top-mods.json` is present, `actionStatusDiagnostics.entries` must include explicit rows for discovered workshop ids (up to 10 mods x 5 promoted actions)
    - top-mod rows may be `Skipped` during deterministic/live runs that only execute shipped profile matrix, but each skipped row must include `skipReasonCode`
+
+After matrix runs:
+
+```powershell
+Remove-Item Env:SWFOC_FORCE_PROMOTED_EXTENDER -ErrorAction SilentlyContinue
+```
 
 ## Live Ops checklist (M1)
 

--- a/profiles/default/profiles/base_sweaw.json
+++ b/profiles/default/profiles/base_sweaw.json
@@ -373,7 +373,6 @@
   "metadata": {
     "profileLineage": "base",
     "targetExecutable": "sweaw.exe",
-    "saveRootDefault": "C:\\Users\\Prekzursil\\Saved Games\\Petroglyph",
     "profileAliases": "base_sweaw,sweaw,empire at war,eaw",
     "localPathHints": "sweaw,empire at war",
     "criticalSymbols": "credits,planet_owner,hero_respawn_timer,game_speed,unit_cap",

--- a/profiles/default/profiles/base_swfoc.json
+++ b/profiles/default/profiles/base_swfoc.json
@@ -426,7 +426,6 @@
   "metadata": {
     "profileLineage": "base",
     "targetExecutable": "swfoc.exe",
-    "saveRootDefault": "C:\\Users\\Prekzursil\\Saved Games\\Petroglyph",
     "profileAliases": "base_swfoc,swfoc,forces of corruption,foc",
     "localPathHints": "swfoc,corruption,forces of corruption",
     "criticalSymbols": "credits,planet_owner,hero_respawn_timer,game_speed,unit_cap",

--- a/profiles/default/profiles/universal_auto.json
+++ b/profiles/default/profiles/universal_auto.json
@@ -4,14 +4,8 @@
   "inherits": "base_swfoc",
   "exeTarget": "Swfoc",
   "steamWorkshopId": null,
-  "backendPreference": "extender",
-  "requiredCapabilities": [
-    "set_credits",
-    "freeze_timer",
-    "toggle_fog_reveal",
-    "set_unit_cap",
-    "toggle_instant_build_patch"
-  ],
+  "backendPreference": "auto",
+  "requiredCapabilities": [],
   "hostPreference": "starwarsg_preferred",
   "experimentalFeatures": [
     "overlay_ui"

--- a/tests/SwfocTrainer.Tests/Profiles/ProfileInheritanceTests.cs
+++ b/tests/SwfocTrainer.Tests/Profiles/ProfileInheritanceTests.cs
@@ -50,4 +50,22 @@ public sealed class ProfileInheritanceTests
             "universal_auto"
         ]);
     }
+
+    [Fact]
+    public async Task UniversalAutoProfile_Should_Default_To_AutoBackendPreference()
+    {
+        var root = TestPaths.FindRepoRoot();
+        var options = new ProfileRepositoryOptions
+        {
+            ProfilesRootPath = Path.Combine(root, "profiles", "default")
+        };
+
+        var repository = new FileSystemProfileRepository(options);
+        var profile = await repository.ResolveInheritedProfileAsync("universal_auto");
+
+        profile.BackendPreference.Should().Be("auto");
+        profile.Actions.Should().ContainKey("set_credits");
+        profile.Actions.Should().ContainKey("freeze_timer");
+        profile.Actions.Should().ContainKey("set_unit_cap");
+    }
 }

--- a/tests/SwfocTrainer.Tests/Profiles/ProfileMetadataPortabilityTests.cs
+++ b/tests/SwfocTrainer.Tests/Profiles/ProfileMetadataPortabilityTests.cs
@@ -1,0 +1,30 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using SwfocTrainer.Tests.Common;
+using Xunit;
+
+namespace SwfocTrainer.Tests.Profiles;
+
+public sealed class ProfileMetadataPortabilityTests
+{
+    private static readonly Regex UserScopedWindowsSaveRootPattern = new(
+        "\"saveRootDefault\"\\s*:\\s*\"[A-Za-z]:\\\\\\\\Users\\\\\\\\",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    [Fact]
+    public void DefaultProfiles_ShouldNotContain_UserSpecific_SaveRootDefaults()
+    {
+        var root = TestPaths.FindRepoRoot();
+        var profileDirectory = Path.Combine(root, "profiles", "default", "profiles");
+        var profileFiles = Directory.GetFiles(profileDirectory, "*.json", SearchOption.TopDirectoryOnly);
+
+        profileFiles.Should().NotBeEmpty();
+
+        foreach (var profileFile in profileFiles)
+        {
+            var content = File.ReadAllText(profileFile);
+            UserScopedWindowsSaveRootPattern.IsMatch(content).Should().BeFalse(
+                because: $"profile metadata in '{Path.GetFileName(profileFile)}' should stay portable across user accounts");
+        }
+    }
+}


### PR DESCRIPTION
### **User description**
## Summary
This PR implements the delta closure wave on current `origin/main` for truthful routing + metadata portability.

Delivered:
- Added `SWFOC_FORCE_PROMOTED_EXTENDER` routing override in `BackendRouter`.
- Default behavior is now non-forced for promoted FoC actions; explicit env override preserves forced behavior for regression runs.
- Added route diagnostics keys:
  - `promotedExtenderOverrideEnabled`
  - `promotedExtenderOverrideSource`
  - `promotedExtenderApplied`
- Updated `universal_auto` profile to `backendPreference: auto` and cleared local promoted capability list.
- Removed hardcoded per-user `saveRootDefault` metadata from `base_swfoc` and `base_sweaw`.
- Added portability guard test: `ProfileMetadataPortabilityTests`.
- Updated runbook/test plan/TODO evidence notes for override semantics and run IDs.

## Why
Current main still forced promoted FoC actions into Extender through router promotion gates, and base profile metadata still contained user-specific save-root paths. This PR closes those deltas without reopening already-landed M2 scope.

## Risk
`risk:high` (runtime routing behavior + live evidence workflow docs).

## Deterministic Verification
- `dotnet restore SwfocTrainer.sln` ✅
- `dotnet build SwfocTrainer.sln -c Release --no-restore` ✅
- `dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release --no-build --filter "FullyQualifiedName!~SwfocTrainer.Tests.Profiles.Live&FullyQualifiedName!~RuntimeAttachSmokeTests"` ✅ (`Passed: 233, Failed: 0`)

## Live Evidence (TACTICAL)
Default routing run:
- `TestResults/runs/20260301-004145/repro-bundle.json`
- `classification=blocked_environment` (no swfoc process detected)

Forced override regression run (`SWFOC_FORCE_PROMOTED_EXTENDER=1`):
- `TestResults/runs/20260301-004232/repro-bundle.json`
- `classification=blocked_environment` (no swfoc process detected)

Bundle schema validation:
- `tools/validate-repro-bundle.ps1` strict validation passed for both run IDs.

## Reliability Evidence Contract
repro bundle json: TestResults/runs/20260301-004145/repro-bundle.json
classification: blocked_environment


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implement `SWFOC_FORCE_PROMOTED_EXTENDER` environment override for promoted FoC action routing
  - Default behavior is non-forced (routes to legacy backend)
  - Override enables forced routing to Extender with fail-closed semantics
  - Add route diagnostics keys for override state tracking

- Remove hardcoded user-specific save-root paths from base profiles for portability

- Update `universal_auto` profile to `backendPreference: auto` and clear promoted capability list

- Add comprehensive test coverage for override semantics and profile metadata portability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BackendRouter"] -->|"reads env var"| B["SWFOC_FORCE_PROMOTED_EXTENDER"]
  B -->|"disabled default"| C["Legacy Backend Routing"]
  B -->|"enabled override"| D["Extender Promotion"]
  C -->|"diagnostics"| E["Override State Keys"]
  D -->|"diagnostics"| E
  F["Base Profiles"] -->|"remove hardcoded"| G["User Save Paths"]
  H["universal_auto"] -->|"change to"| I["backendPreference: auto"]
  H -->|"clear"| J["Required Capabilities"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>BackendRouter.cs</strong><dd><code>Add promoted extender override environment variable semantics</code></dd></td>
  <td><a href="https://github.com/Prekzursil/SWFOC-Mod-Menu/pull/90/files#diff-1bd03f0bf346d9a9a3b191e8d1dec00f873ba6ad3e8c73d471171ccce4b772a0">+43/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>BackendRouterTests.cs</strong><dd><code>Add override scope tests and update routing behavior assertions</code></dd></td>
  <td><a href="https://github.com/Prekzursil/SWFOC-Mod-Menu/pull/90/files#diff-e8dfbfd79d2c7c48a6104d2c09d0aaa95962c125b5089311d403df9ffe4312ca">+169/-13</a></td>

</tr>

<tr>
  <td><strong>ProfileInheritanceTests.cs</strong><dd><code>Add test for universal_auto backend preference default</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Prekzursil/SWFOC-Mod-Menu/pull/90/files#diff-be743b35f9f18b6cd0ef0342805c7d314ecd4ce6c9acc9e958f8ce37cbab947f">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ProfileMetadataPortabilityTests.cs</strong><dd><code>Add portability guard test for user-specific save paths</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Prekzursil/SWFOC-Mod-Menu/pull/90/files#diff-698f8d25b4dd13ab2a9eeb2608f2bc670a047dc11df2742cd2d1b22ab7587d22">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>base_sweaw.json</strong><dd><code>Remove hardcoded user save-root default path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Prekzursil/SWFOC-Mod-Menu/pull/90/files#diff-52c2e93dc29eb0fa8b063210afda10beb2fba797b16751177b151ce13ad1370c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>base_swfoc.json</strong><dd><code>Remove hardcoded user save-root default path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Prekzursil/SWFOC-Mod-Menu/pull/90/files#diff-6fc730f88a1e6b3bcecd3d919e2475e665d26ef90a1980baf73436a5542beb72">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>universal_auto.json</strong><dd><code>Change backend preference to auto and clear capabilities</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Prekzursil/SWFOC-Mod-Menu/pull/90/files#diff-d5f02c0e00eb6d794a3f1f54ffcea9c2135d7305d5400add18f0a55678b6d69b">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>TODO.md</strong><dd><code>Document delta closure wave completion with evidence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Prekzursil/SWFOC-Mod-Menu/pull/90/files#diff-5c6a1301c6b59b30a040d747d065e861d3dd98bde0e5a4356d92d594e9835986">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LIVE_VALIDATION_RUNBOOK.md</strong><dd><code>Update promoted action matrix evidence procedures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Prekzursil/SWFOC-Mod-Menu/pull/90/files#diff-a9d38e3fd2ba69b27f81546aa08ccaba5acb502bf09c3175228d7c8cacc7f75d">+17/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TEST_PLAN.md</strong><dd><code>Update test expectations for promoted routing override</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Prekzursil/SWFOC-Mod-Menu/pull/90/files#diff-38ad0c9413094a5b3d3c762f09abf7b05dcab6d72001849abf6274afbdde2c9d">+15/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional override mechanism for promoted action routing via environment variable
  * Universal Auto profile now defaults to auto backend preference

* **Improvements**
  * Removed user-specific paths from profile metadata to improve portability across accounts

* **Documentation**
  * Updated validation and test guidance for new routing configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->