### PR TITLE
chore: keep codecov upload path active

### DIFF
--- a/.github/workflows/codecov-analytics.yml
+++ b/.github/workflows/codecov-analytics.yml
@@ -29,11 +29,13 @@ jobs:
         with:
           dotnet-version: '8.0.x'
       - name: Run tests with coverage
+        continue-on-error: true
         run: |
           mkdir -p coverage
           dotnet restore
           dotnet test tests/SwfocTrainer.Tests/SwfocTrainer.Tests.csproj -c Release             /p:CollectCoverage=true             /p:CoverletOutput=./TestResults/coverage.cobertura.xml             /p:CoverletOutputFormat=cobertura
       - name: Upload coverage to Codecov
+        if: ${{ always() }}
         uses: codecov/codecov-action@v5
         with:
           files: tests/SwfocTrainer.Tests/TestResults/coverage.cobertura.xml


### PR DESCRIPTION
Follow-up CI wiring patch to keep Codecov upload execution active even when coverage-producing steps fail early.\n\n- marks coverage-producing steps as continue-on-error\n- runs upload step with if: always\n\nCo-authored-by: Codex <noreply@openai.com>