### PR TITLE
fix(codeql): resolve all 30 LINQ optimization findings

### DIFF
--- a/src/SwfocTrainer.Profiles/Services/GitHubProfileUpdateService.cs
+++ b/src/SwfocTrainer.Profiles/Services/GitHubProfileUpdateService.cs
@@ -50,14 +50,10 @@ public sealed class GitHubProfileUpdateService : IProfileUpdateService
         var local = await _repository.LoadManifestAsync(cancellationToken);
         var localVersions = local.Profiles.ToDictionary(x => x.Id, x => x.Version, StringComparer.OrdinalIgnoreCase);
 
-        var updates = new List<string>();
-        foreach (var entry in remote.Profiles)
-        {
-            if (!localVersions.TryGetValue(entry.Id, out var localVersion) || !string.Equals(localVersion, entry.Version, StringComparison.OrdinalIgnoreCase))
-            {
-                updates.Add(entry.Id);
-            }
-        }
+        var updates = remote.Profiles
+            .Where(entry => !localVersions.TryGetValue(entry.Id, out var localVersion) || !string.Equals(localVersion, entry.Version, StringComparison.OrdinalIgnoreCase))
+            .Select(entry => entry.Id)
+            .ToList();
 
         return updates;
     }

--- a/src/SwfocTrainer.Profiles/Services/ModOnboardingService.cs
+++ b/src/SwfocTrainer.Profiles/Services/ModOnboardingService.cs
@@ -528,12 +528,9 @@ public sealed class ModOnboardingService : IModOnboardingService
             }
         }
 
-        foreach (var hint in inferred.Where(x => !string.IsNullOrWhiteSpace(x)))  // NOSONAR
+        foreach (var hint in inferred.Where(x => !string.IsNullOrWhiteSpace(x) && IsPathHintCandidate(x)))  // NOSONAR
         {
-            if (IsPathHintCandidate(hint))
-            {
-                merged.Add(hint);
-            }
+            merged.Add(hint);
         }
 
         return merged.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).Take(16).ToArray();

--- a/src/SwfocTrainer.Runtime/Services/LaunchContextResolver.cs
+++ b/src/SwfocTrainer.Runtime/Services/LaunchContextResolver.cs
@@ -208,12 +208,9 @@ public sealed class LaunchContextResolver : ILaunchContextResolver
         foreach (var profile in profiles)
         {
             var score = 0;
-            foreach (var hint in BuildHints(profile))  // NOSONAR
+            foreach (var hint in BuildHints(profile).Where(h => modPathNormalized.Contains(h, StringComparison.OrdinalIgnoreCase)))  // NOSONAR
             {
-                if (modPathNormalized.Contains(hint, StringComparison.OrdinalIgnoreCase))
-                {
-                    score = Math.Max(score, hint.Length);
-                }
+                score = Math.Max(score, hint.Length);
             }
 
             if (score == 0)
@@ -320,12 +317,9 @@ public sealed class LaunchContextResolver : ILaunchContextResolver
                 continue;
             }
 
-            foreach (var id in raw.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))  // NOSONAR
+            foreach (var id in raw.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).Where(id => !string.IsNullOrWhiteSpace(id)))  // NOSONAR
             {
-                if (!string.IsNullOrWhiteSpace(id))
-                {
-                    required.Add(id);
-                }
+                required.Add(id);
             }
         }
 
@@ -354,13 +348,11 @@ public sealed class LaunchContextResolver : ILaunchContextResolver
                 continue;
             }
 
-            foreach (var part in raw.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+            foreach (var normalized in raw.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                .Select(NormalizeToken)
+                .Where(n => !string.IsNullOrWhiteSpace(n)))
             {
-                var normalized = NormalizeToken(part);
-                if (!string.IsNullOrWhiteSpace(normalized))
-                {
-                    hints.Add(normalized);
-                }
+                hints.Add(normalized!);
             }
         }
 
@@ -396,12 +388,10 @@ public sealed class LaunchContextResolver : ILaunchContextResolver
         var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (!string.IsNullOrWhiteSpace(process.CommandLine))
         {
-            foreach (Match match in SteamModRegex.Matches(process.CommandLine))  // NOSONAR
+            foreach (var match in SteamModRegex.Matches(process.CommandLine).Cast<Match>()
+                .Where(m => m.Groups.Count > 1 && !string.IsNullOrWhiteSpace(m.Groups[1].Value)))  // NOSONAR
             {
-                if (match.Groups.Count > 1 && !string.IsNullOrWhiteSpace(match.Groups[1].Value))
-                {
-                    ids.Add(match.Groups[1].Value);
-                }
+                ids.Add(match.Groups[1].Value);
             }
         }
 

--- a/src/SwfocTrainer.Runtime/Services/ModDependencyValidator.cs
+++ b/src/SwfocTrainer.Runtime/Services/ModDependencyValidator.cs
@@ -261,16 +261,9 @@ public sealed class ModDependencyValidator : IModDependencyValidator
 
     private static string? FindWorkshopFolder(string id, IReadOnlyList<string> workshopRoots)
     {
-        foreach (var root in workshopRoots)
-        {
-            var candidate = Path.Combine(root, id);
-            if (Directory.Exists(candidate))
-            {
-                return candidate;
-            }
-        }
-
-        return null;
+        return workshopRoots
+            .Select(root => Path.Combine(root, id))
+            .FirstOrDefault(Directory.Exists);
     }
 
     private static bool HasMarker(string root, string marker)
@@ -320,27 +313,15 @@ public sealed class ModDependencyValidator : IModDependencyValidator
             return;
         }
 
-        foreach (var root in roots.ToArray())
+        foreach (var hintedPath in roots.ToArray()
+            .Select(root => Directory.GetParent(root)?.FullName)
+            .Where(parent => !string.IsNullOrWhiteSpace(parent))
+            .SelectMany(parent => parentHints
+                .Where(hint => !hint.Contains(PathTraversalToken, StringComparison.Ordinal))
+                .Select(hint => Path.Combine(parent!, hint)))
+            .Where(Directory.Exists))
         {
-            var parent = Directory.GetParent(root)?.FullName;
-            if (string.IsNullOrWhiteSpace(parent))
-            {
-                continue;
-            }
-
-            foreach (var hint in parentHints)
-            {
-                if (hint.Contains(PathTraversalToken, StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                var hintedPath = Path.Combine(parent, hint);
-                if (Directory.Exists(hintedPath))
-                {
-                    roots.Add(hintedPath);
-                }
-            }
+            roots.Add(hintedPath);
         }
     }
 

--- a/src/SwfocTrainer.Runtime/Services/ProcessLocator.cs
+++ b/src/SwfocTrainer.Runtime/Services/ProcessLocator.cs
@@ -325,20 +325,12 @@ public sealed class ProcessLocator : IProcessLocator
         }
 
         var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var raw in workshopIds)
+        foreach (var token in workshopIds
+            .Where(raw => !string.IsNullOrWhiteSpace(raw))
+            .SelectMany(raw => raw.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+            .Where(token => !string.IsNullOrWhiteSpace(token)))  // NOSONAR
         {
-            if (string.IsNullOrWhiteSpace(raw))
-            {
-                continue;
-            }
-
-            foreach (var token in raw.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))  // NOSONAR
-            {
-                if (!string.IsNullOrWhiteSpace(token))
-                {
-                    ids.Add(token);
-                }
-            }
+            ids.Add(token);
         }
 
         return ids
@@ -515,21 +507,17 @@ public sealed class ProcessLocator : IProcessLocator
         }
 
         var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (Match match in Regex.Matches(commandLine, @"steammod\s*=\s*(\d+)", RegexOptions.IgnoreCase))  // NOSONAR
+        foreach (var match in Regex.Matches(commandLine, @"steammod\s*=\s*(\d+)", RegexOptions.IgnoreCase).Cast<Match>()
+            .Where(m => m.Groups.Count > 1 && !string.IsNullOrWhiteSpace(m.Groups[1].Value)))  // NOSONAR
         {
-            if (match.Groups.Count > 1 && !string.IsNullOrWhiteSpace(match.Groups[1].Value))
-            {
-                ids.Add(match.Groups[1].Value);
-            }
+            ids.Add(match.Groups[1].Value);
         }
 
         // Also infer IDs from mod paths containing workshop content folder segments.
-        foreach (Match match in Regex.Matches(commandLine, @"[\\/]+32470[\\/]+(\d+)", RegexOptions.IgnoreCase))  // NOSONAR
+        foreach (var match in Regex.Matches(commandLine, @"[\\/]+32470[\\/]+(\d+)", RegexOptions.IgnoreCase).Cast<Match>()
+            .Where(m => m.Groups.Count > 1 && !string.IsNullOrWhiteSpace(m.Groups[1].Value)))  // NOSONAR
         {
-            if (match.Groups.Count > 1 && !string.IsNullOrWhiteSpace(match.Groups[1].Value))
-            {
-                ids.Add(match.Groups[1].Value);
-            }
+            ids.Add(match.Groups[1].Value);
         }
 
         return ids.OrderBy(x => x, StringComparer.Ordinal).ToArray();

--- a/src/SwfocTrainer.Runtime/Services/RuntimeAdapter.cs
+++ b/src/SwfocTrainer.Runtime/Services/RuntimeAdapter.cs
@@ -1981,18 +1981,16 @@ public sealed partial class RuntimeAdapter : IRuntimeAdapter
         IReadOnlyList<string> keys,
         out string? value)
     {
-        value = null;
-        foreach (var key in keys)
-        {
-            if (TryReadDiagnosticString(diagnostics, key, out var resolved) &&
-                !string.IsNullOrWhiteSpace(resolved))
+        var match = keys
+            .Select(key =>
             {
-                value = resolved;
-                return true;
-            }
-        }
+                TryReadDiagnosticString(diagnostics, key, out var resolved);
+                return resolved;
+            })
+            .FirstOrDefault(resolved => !string.IsNullOrWhiteSpace(resolved));
 
-        return false;
+        value = match;
+        return match is not null;
     }
 
     private static bool TryReadDiagnosticString(
@@ -5330,16 +5328,15 @@ public sealed partial class RuntimeAdapter : IRuntimeAdapter
 
     private static List<CreditsHookCandidate> ParseCreditsHookCandidates(byte[] moduleBytes, IEnumerable<int> offsets)
     {
-        var candidates = new List<CreditsHookCandidate>();
-        foreach (var offset in offsets)
-        {
-            if (TryParseCreditsCvttss2siInstruction(moduleBytes, offset, out var instruction))
+        return offsets
+            .Select(offset =>
             {
-                candidates.Add(new CreditsHookCandidate(offset, instruction));
-            }
-        }
-
-        return candidates;
+                var parsed = TryParseCreditsCvttss2siInstruction(moduleBytes, offset, out var instruction);
+                return (Offset: offset, Instruction: instruction, Parsed: parsed);
+            })
+            .Where(x => x.Parsed)
+            .Select(x => new CreditsHookCandidate(x.Offset, x.Instruction))
+            .ToList();
     }
 
     private static List<CreditsHookCandidate> SelectImmediateStoreCandidates(

--- a/src/SwfocTrainer.Runtime/Services/WorkshopInventoryService.Chains.cs
+++ b/src/SwfocTrainer.Runtime/Services/WorkshopInventoryService.Chains.cs
@@ -148,12 +148,10 @@ internal static class WorkshopInventoryChainResolver
         ISet<string> visited,
         ICollection<string> ordered)
     {
-        if (string.IsNullOrWhiteSpace(currentId) || !map.ContainsKey(currentId) || !visited.Add(currentId))
+        if (string.IsNullOrWhiteSpace(currentId) || !map.TryGetValue(currentId, out var parent) || !visited.Add(currentId))
         {
             return;
         }
-
-        var parent = map[currentId];
         foreach (var ancestor in parent.ParentWorkshopIds)
         {
             BuildParentStack(ancestor, map, visited, ordered);

--- a/src/SwfocTrainer.Runtime/Services/WorkshopInventoryService.cs
+++ b/src/SwfocTrainer.Runtime/Services/WorkshopInventoryService.cs
@@ -110,13 +110,11 @@ public sealed class WorkshopInventoryService : IWorkshopInventoryService
 
         diagnostics.Add($"manifest={manifestPath}");
         var text = File.ReadAllText(manifestPath);
-        foreach (Match match in InstalledIdRegex.Matches(text))
+        foreach (var id in InstalledIdRegex.Matches(text).Cast<Match>()
+            .Select(match => match.Groups["id"].Value)
+            .Where(id => !string.IsNullOrWhiteSpace(id)))
         {
-            var id = match.Groups["id"].Value;
-            if (!string.IsNullOrWhiteSpace(id))
-            {
-                ids.Add(id);
-            }
+            ids.Add(id);
         }
     }
 
@@ -129,13 +127,11 @@ public sealed class WorkshopInventoryService : IWorkshopInventoryService
                 continue;
             }
 
-            foreach (var directory in Directory.EnumerateDirectories(root))
+            foreach (var id in Directory.EnumerateDirectories(root)
+                .Select(Path.GetFileName)
+                .Where(id => !string.IsNullOrWhiteSpace(id) && id!.All(char.IsDigit)))
             {
-                var id = Path.GetFileName(directory);
-                if (!string.IsNullOrWhiteSpace(id) && id.All(char.IsDigit))
-                {
-                    ids.Add(id);
-                }
+                ids.Add(id!);
             }
         }
     }
@@ -308,14 +304,15 @@ public sealed class WorkshopInventoryService : IWorkshopInventoryService
             return Array.Empty<WorkshopInventoryItem>();
         }
 
-        var mappedItems = new List<WorkshopInventoryItem>();
-        foreach (var detail in detailsNode.EnumerateArray())
-        {
-            if (TryMapItem(detail, out var mapped))
+        var mappedItems = detailsNode.EnumerateArray()
+            .Select(detail =>
             {
-                mappedItems.Add(mapped);
-            }
-        }
+                var found = TryMapItem(detail, out var mapped);
+                return (Found: found, Item: mapped);
+            })
+            .Where(x => x.Found)
+            .Select(x => x.Item)
+            .ToList();
 
         return mappedItems;
     }
@@ -438,15 +435,13 @@ public sealed class WorkshopInventoryService : IWorkshopInventoryService
         }
 
         var tags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var tag in tagsNode.EnumerateArray())
-        {
-            var value = tag.TryGetProperty("tag", out var tagName)
+        foreach (var value in tagsNode.EnumerateArray()
+            .Select(tag => tag.TryGetProperty("tag", out var tagName)
                 ? tagName.GetString()
-                : tag.GetString();
-            if (!string.IsNullOrWhiteSpace(value))
-            {
-                tags.Add(value.Trim());
-            }
+                : tag.GetString())
+            .Where(value => !string.IsNullOrWhiteSpace(value)))
+        {
+            tags.Add(value!.Trim());
         }
 
         return tags.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToArray();
@@ -489,13 +484,11 @@ public sealed class WorkshopInventoryService : IWorkshopInventoryService
             return;
         }
 
-        foreach (Match match in SteamModRegex.Matches(description))
+        foreach (var id in SteamModRegex.Matches(description).Cast<Match>()
+            .Select(match => match.Groups["id"].Value)
+            .Where(id => !string.IsNullOrWhiteSpace(id) && !string.Equals(id, selfId, StringComparison.OrdinalIgnoreCase)))
         {
-            var id = match.Groups["id"].Value;
-            if (!string.IsNullOrWhiteSpace(id) && !string.Equals(id, selfId, StringComparison.OrdinalIgnoreCase))
-            {
-                parents.Add(id);
-            }
+            parents.Add(id);
         }
     }
 

--- a/src/SwfocTrainer.Saves/Services/BinarySaveCodec.cs
+++ b/src/SwfocTrainer.Saves/Services/BinarySaveCodec.cs
@@ -57,21 +57,13 @@ public sealed class BinarySaveCodec : ISaveCodec
         var errors = new List<string>();
         var warnings = new List<string>();
 
-        foreach (var block in schema.RootBlocks)
-        {
-            if (block.Offset < 0 || block.Offset + block.Length > document.Raw.Length)
-            {
-                errors.Add($"Block '{block.Id}' is out of range ({block.Offset}..{block.Offset + block.Length})");
-            }
-        }
+        errors.AddRange(schema.RootBlocks
+            .Where(block => block.Offset < 0 || block.Offset + block.Length > document.Raw.Length)
+            .Select(block => $"Block '{block.Id}' is out of range ({block.Offset}..{block.Offset + block.Length})"));
 
-        foreach (var field in schema.FieldDefs)
-        {
-            if (field.Offset < 0 || field.Offset + field.Length > document.Raw.Length)
-            {
-                errors.Add($"Field '{field.Id}' is out of range ({field.Offset}..{field.Offset + field.Length})");
-            }
-        }
+        errors.AddRange(schema.FieldDefs
+            .Where(field => field.Offset < 0 || field.Offset + field.Length > document.Raw.Length)
+            .Select(field => $"Field '{field.Id}' is out of range ({field.Offset}..{field.Offset + field.Length})"));
 
         foreach (var rule in schema.ValidationRules)
         {

--- a/src/SwfocTrainer.Saves/Services/SavePatchApplyService.Helpers.cs
+++ b/src/SwfocTrainer.Saves/Services/SavePatchApplyService.Helpers.cs
@@ -209,15 +209,15 @@ internal sealed class SavePatchApplyServiceHelper
             .OrderByDescending(info => info.LastWriteTimeUtc)
             .Select(info => info.FullName);
 
-        foreach (var candidate in backupCandidates)
-        {
-            if (TryNormalizeBackupCandidatePath(candidate, out var candidatePath, out _))
+        return backupCandidates
+            .Select(candidate =>
             {
-                return candidatePath;
-            }
-        }
-
-        return null;
+                var found = TryNormalizeBackupCandidatePath(candidate, out var candidatePath, out _);
+                return (Found: found, Path: candidatePath);
+            })
+            .Where(x => x.Found)
+            .Select(x => x.Path)
+            .FirstOrDefault();
     }
 
     private async Task<SelectorApplyAttempt> TryApplySelectorAsync(

--- a/src/SwfocTrainer.Saves/Services/SavePatchPackService.cs
+++ b/src/SwfocTrainer.Saves/Services/SavePatchPackService.cs
@@ -509,12 +509,10 @@ public sealed class SavePatchPackService : ISavePatchPackService
 
     private static void ValidateRawOperationContract(JsonElement operation, int index, ICollection<string> errors)
     {
-        foreach (var field in new[] { "kind", "fieldPath", "fieldId", "valueType", "newValue", "offset" })
+        foreach (var field in new[] { "kind", "fieldPath", "fieldId", "valueType", "newValue", "offset" }
+            .Where(field => !TryGetPropertyIgnoreCase(operation, field, out _)))
         {
-            if (!TryGetPropertyIgnoreCase(operation, field, out _))
-            {
-                errors.Add($"operations[{index}].{field} is required");
-            }
+            errors.Add($"operations[{index}].{field} is required");
         }
 
         if (TryGetPropertyIgnoreCase(operation, "newValue", out var newValue) &&

--- a/tests/SwfocTrainer.Tests/DataIndex/EffectiveGameDataIndexServiceTests.cs
+++ b/tests/SwfocTrainer.Tests/DataIndex/EffectiveGameDataIndexServiceTests.cs
@@ -142,9 +142,8 @@ public sealed class EffectiveGameDataIndexServiceTests
     {
         using var stream = new MemoryStream();
         using var writer = new BinaryWriter(stream, Encoding.ASCII, leaveOpen: true);
-        foreach (var entry in entries)
+        foreach (var encoded in entries.Select(entry => Encoding.ASCII.GetBytes(entry.Path)))
         {
-            var encoded = Encoding.ASCII.GetBytes(entry.Path);
             writer.Write((ushort)encoded.Length);
             writer.Write((ushort)0);
             writer.Write(encoded);

--- a/tests/SwfocTrainer.Tests/Meg/MegArchiveReaderTests.cs
+++ b/tests/SwfocTrainer.Tests/Meg/MegArchiveReaderTests.cs
@@ -178,9 +178,8 @@ public sealed class MegArchiveReaderTests
     {
         using var stream = new MemoryStream();
         using var writer = new BinaryWriter(stream, Encoding.ASCII, leaveOpen: true);
-        foreach (var entry in entries)
+        foreach (var encoded in entries.Select(entry => Encoding.ASCII.GetBytes(entry.Path)))
         {
-            var encoded = Encoding.ASCII.GetBytes(entry.Path);
             writer.Write((ushort)encoded.Length);
             writer.Write((ushort)0);
             writer.Write(encoded);

--- a/tests/SwfocTrainer.Tests/Profiles/LiveActionSmokeTests.cs
+++ b/tests/SwfocTrainer.Tests/Profiles/LiveActionSmokeTests.cs
@@ -77,13 +77,13 @@ public sealed class LiveActionSmokeTests
     private void LogResolvedSymbols(AttachSession session)
     {
         _output.WriteLine($"Resolved symbols: {session.Symbols.Symbols.Count}");
-        foreach (var symbolName in session.Symbols.Symbols.Keys.OrderBy(x => x))
+        foreach (var (symbolName, symbol) in session.Symbols.Symbols
+            .OrderBy(kvp => kvp.Key)
+            .Where(kvp => kvp.Value is not null)
+            .Select(kvp => (kvp.Key, kvp.Value)))
         {
-            if (session.Symbols.Symbols.TryGetValue(symbolName, out var symbol))
-            {
-                _output.WriteLine(
-                    $"{symbolName}: 0x{symbol.Address.ToInt64():X} source={symbol.Source} diag={symbol.Diagnostics}");
-            }
+            _output.WriteLine(
+                $"{symbolName}: 0x{symbol.Address.ToInt64():X} source={symbol.Source} diag={symbol.Diagnostics}");
         }
     }
 

--- a/tests/SwfocTrainer.Tests/Runtime/LaunchContextRuntimeScriptParityTests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/LaunchContextRuntimeScriptParityTests.cs
@@ -80,20 +80,13 @@ public sealed class LaunchContextRuntimeScriptParityTests
 
     private static IReadOnlyDictionary<string, ScriptRecommendation> BuildScriptRecommendationsByName(JsonArray results)
     {
-        var byName = new Dictionary<string, ScriptRecommendation>(StringComparer.OrdinalIgnoreCase);
-        foreach (var node in results)
-        {
-            var obj = node!.AsObject();
-            var caseName = obj["input"]?["name"]?.GetValue<string>();
-            if (string.IsNullOrWhiteSpace(caseName))
-            {
-                continue;
-            }
-
-            byName[caseName] = BuildScriptRecommendation(obj);
-        }
-
-        return byName;
+        return results
+            .Select(node => node!.AsObject())
+            .Where(obj => !string.IsNullOrWhiteSpace(obj["input"]?["name"]?.GetValue<string>()))
+            .ToDictionary(
+                obj => obj["input"]!["name"]!.GetValue<string>(),
+                BuildScriptRecommendation,
+                StringComparer.OrdinalIgnoreCase);
     }
 
     private static ScriptRecommendation BuildScriptRecommendation(JsonObject obj)
@@ -142,15 +135,8 @@ public sealed class LaunchContextRuntimeScriptParityTests
             ("py", "-3")
         };
 
-        foreach (var candidate in candidates)
-        {
-            if (CanExecute(candidate))
-            {
-                return candidate;
-            }
-        }
-
-        return null;
+        var match = candidates.Where(CanExecute).Select(c => ((string FileName, string PrefixArgs)?)c).FirstOrDefault();
+        return match;
     }
 
     private static bool CanExecute((string FileName, string PrefixArgs) launcher)

--- a/tests/SwfocTrainer.Tests/Runtime/LaunchContextScriptSmokeTests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/LaunchContextScriptSmokeTests.cs
@@ -46,15 +46,8 @@ public sealed class LaunchContextScriptSmokeTests
             ("py", "-3")
         };
 
-        foreach (var candidate in candidates)
-        {
-            if (CanExecute(candidate))
-            {
-                return candidate;
-            }
-        }
-
-        return null;
+        var match = candidates.Where(CanExecute).Select(c => ((string FileName, string PrefixArgs)?)c).FirstOrDefault();
+        return match;
     }
 
     private static bool CanExecute((string FileName, string PrefixArgs) launcher)

--- a/tests/SwfocTrainer.Tests/Saves/SaveCorpusRoundTripTests.cs
+++ b/tests/SwfocTrainer.Tests/Saves/SaveCorpusRoundTripTests.cs
@@ -34,9 +34,8 @@ public sealed class SaveCorpusRoundTripTests
         };
 
         var codec = new BinarySaveCodec(options, NullLogger<BinarySaveCodec>.Instance);
-        foreach (var fixtureName in manifest.Fixtures)
+        foreach (var fixturePath in manifest.Fixtures.Select(name => Path.Combine(fixtureDir, name)))
         {
-            var fixturePath = Path.Combine(fixtureDir, fixtureName);
             File.Exists(fixturePath).Should().BeTrue();
             var fixture = JsonSerializer.Deserialize<SaveCorpusFixture>(await File.ReadAllTextAsync(fixturePath), JsonOptions);
             fixture.Should().NotBeNull();


### PR DESCRIPTION
## Summary
- Replace 20 `foreach` + `if` patterns with `.Where()` (cs/linq/missed-where)
- Replace 10 manual collection building loops with `.Select()` / `.ToDictionary()` / `.FirstOrDefault()` (cs/linq/missed-select)
- Replace 1 `ContainsKey` + indexer with `TryGetValue` (cs/inefficient-containskey)

### Files changed (17)
**Source (11):** GitHubProfileUpdateService, ModOnboardingService, LaunchContextResolver, ModDependencyValidator, ProcessLocator, RuntimeAdapter, WorkshopInventoryService (+Chains), BinarySaveCodec, SavePatchApplyService.Helpers, SavePatchPackService

**Tests (6):** LiveActionSmokeTests, LaunchContextRuntimeScriptParityTests, LaunchContextScriptSmokeTests, EffectiveGameDataIndexServiceTests, MegArchiveReaderTests, SaveCorpusRoundTripTests

## Test plan
- [x] `dotnet build SwfocTrainer.sln -c Release` passes with 0 errors, 0 warnings
- [ ] CI build and test suite pass
- [ ] CodeQL re-scan shows 0 remaining LINQ optimization alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)