### PR TITLE
fix(quality): resolve final 4 CodeQL alerts

### DIFF
--- a/src/SwfocTrainer.Runtime/Services/ModDependencyValidator.cs
+++ b/src/SwfocTrainer.Runtime/Services/ModDependencyValidator.cs
@@ -187,26 +187,23 @@ public sealed class ModDependencyValidator : IModDependencyValidator
     {
         var roots = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var root in DriveInfo.GetDrives().Where(drive => drive.IsReady).Select(drive => drive.RootDirectory.FullName))
+        foreach (var steamRoot in DriveInfo.GetDrives()
+                     .Where(drive => drive.IsReady)
+                     .SelectMany(drive => new[]
+                     {
+                         Path.Join(drive.RootDirectory.FullName, "SteamLibrary"),
+                         Path.Join(drive.RootDirectory.FullName, "Program Files (x86)", "Steam"),
+                         Path.Join(drive.RootDirectory.FullName, "Program Files", "Steam")
+                     }))
         {
-            var steamCandidates = new[]
+            var workshopRoot = Path.Join(steamRoot, "steamapps", "workshop", "content", WorkshopAppId);
+            if (Directory.Exists(workshopRoot))
             {
-                Path.Join(root, "SteamLibrary"),
-                Path.Join(root, "Program Files (x86)", "Steam"),
-                Path.Join(root, "Program Files", "Steam")
-            };
-
-            foreach (var steamRoot in steamCandidates)
-            {
-                var workshopRoot = Path.Join(steamRoot, "steamapps", "workshop", "content", WorkshopAppId);
-                if (Directory.Exists(workshopRoot))
-                {
-                    roots.Add(workshopRoot);
-                }
-
-                var libraryFoldersPath = Path.Join(steamRoot, "steamapps", "libraryfolders.vdf");
-                AddWorkshopRootsFromLibraryFolders(libraryFoldersPath, roots);
+                roots.Add(workshopRoot);
             }
+
+            var libraryFoldersPath = Path.Join(steamRoot, "steamapps", "libraryfolders.vdf");
+            AddWorkshopRootsFromLibraryFolders(libraryFoldersPath, roots);
         }
 
         foreach (var linuxCandidate in LinuxWorkshopCandidates.Where(Directory.Exists))

--- a/tests/SwfocTrainer.Tests/App/ProgramServiceRegistrationTests.cs
+++ b/tests/SwfocTrainer.Tests/App/ProgramServiceRegistrationTests.cs
@@ -45,7 +45,7 @@ public sealed class ProgramServiceRegistrationTests
                 .GetProperty("RemoteManifestUrl", BindingFlags.Instance | BindingFlags.Public)?
                 .GetValue(instance) as string;
             remoteManifestUrl.Should().NotBeNull();
-            remoteManifestUrl!.Should().Be("https://example.invalid/manifest.json");
+            remoteManifestUrl.Should().Be("https://example.invalid/manifest.json");
         }
         finally
         {

--- a/tests/SwfocTrainer.Tests/Profiles/ModOnboardingCalibrationCoverageSweepTests.cs
+++ b/tests/SwfocTrainer.Tests/Profiles/ModOnboardingCalibrationCoverageSweepTests.cs
@@ -81,10 +81,10 @@ public sealed class ModOnboardingCalibrationCoverageSweepTests
                 "steammod=222")
         };
 
-        var workshopIds = InvokeStatic<IReadOnlyList<string>>(nameof(ModOnboardingService), "InferWorkshopIds", (object)samples);
+        var workshopIds = InvokeStatic<IReadOnlyList<string>>(nameof(ModOnboardingService), "InferWorkshopIds", new object[] { samples });
         workshopIds.Should().Equal("111", "222");
 
-        var pathHints = InvokeStatic<IReadOnlyList<string>>(nameof(ModOnboardingService), "InferPathHints", (object)samples);
+        var pathHints = InvokeStatic<IReadOnlyList<string>>(nameof(ModOnboardingService), "InferPathHints", new object[] { samples });
         pathHints.Should().Contain("republic");
         pathHints.Should().Contain("rise");
         pathHints.Should().Contain("revenge");


### PR DESCRIPTION
## Summary
- Fix 4 remaining CodeQL alerts found after main-branch re-scan
- `cs/useless-upcast` (2): Replace `(object)` cast with explicit `new object[]` array construction
- `cs/dereferenced-value-may-be-null` (1): Remove redundant `!` null-forgiving operator  
- `cs/linq/missed-select` (1): Flatten nested foreach with `SelectMany`

## Test plan
- [x] Build passes (0 warnings, 0 errors)
- [ ] CodeQL scan shows 0 open alerts after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Steam workshop content discovery to properly scan all configured library locations.

* **Tests**
  * Refined test assertions and updated reflection-based test invocations for improved test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->