### PR TITLE
fix(quality): resolve last CodeQL null-deref alert

### DIFF
--- a/tests/SwfocTrainer.Tests/App/ProgramServiceRegistrationTests.cs
+++ b/tests/SwfocTrainer.Tests/App/ProgramServiceRegistrationTests.cs
@@ -40,11 +40,10 @@ public sealed class ProgramServiceRegistrationTests
             var optionsDescriptor = services.Single(x => x.ServiceType is { FullName: "SwfocTrainer.Profiles.Config.ProfileRepositoryOptions" });
             optionsDescriptor.ImplementationInstance.Should().NotBeNull();
             var instance = optionsDescriptor.ImplementationInstance!;
-            var remoteManifestUrl = instance
+            var remoteManifestUrl = (instance
                 .GetType()
                 .GetProperty("RemoteManifestUrl", BindingFlags.Instance | BindingFlags.Public)?
-                .GetValue(instance) as string;
-            remoteManifestUrl.Should().NotBeNull();
+                .GetValue(instance) as string) ?? string.Empty;
             remoteManifestUrl.Should().Be("https://example.invalid/manifest.json");
         }
         finally


### PR DESCRIPTION
## Summary
- Use `?? string.Empty` null-coalescing to eliminate the final `cs/dereferenced-value-may-be-null` CodeQL alert
- This is the last of 454 CodeQL alerts (454 → 0)

## Test plan
- [x] Build passes (0 warnings, 0 errors)
- [ ] CodeQL shows 0 open alerts after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)