### PR TITLE
test(codeql): clear all 70 test-code CodeQL alerts (real fixes)

### DIFF
--- a/tests/SwfocTrainer.Tests/App/MainViewModelHotkeyHelpersFullCoverageTests.cs
+++ b/tests/SwfocTrainer.Tests/App/MainViewModelHotkeyHelpersFullCoverageTests.cs
@@ -109,7 +109,7 @@ public sealed class MainViewModelHotkeyHelpersFullCoverageTests
     public void BuildDefaultHotkeyPayloadJson_KnownActions_ShouldContainExpectedKey(string actionId, string expectedKey)
     {
         var json = MainViewModelHotkeyHelpers.BuildDefaultHotkeyPayloadJson(actionId);
-        var obj = JsonNode.Parse(json) as JsonObject;
+        var obj = JsonNode.Parse(json)!.AsObject();
 
         obj.Should().NotBeNull();
         obj![expectedKey].Should().NotBeNull();
@@ -119,7 +119,7 @@ public sealed class MainViewModelHotkeyHelpersFullCoverageTests
     public void BuildDefaultHotkeyPayloadJson_UnknownAction_ShouldReturnEmptyObject()
     {
         var json = MainViewModelHotkeyHelpers.BuildDefaultHotkeyPayloadJson("unknown_action");
-        var obj = JsonNode.Parse(json) as JsonObject;
+        var obj = JsonNode.Parse(json)!.AsObject();
 
         obj.Should().NotBeNull();
         obj!.Count.Should().Be(0);
@@ -129,7 +129,7 @@ public sealed class MainViewModelHotkeyHelpersFullCoverageTests
     public void BuildDefaultHotkeyPayloadJson_SetCredits_ShouldHaveLockCreditsKey()
     {
         var json = MainViewModelHotkeyHelpers.BuildDefaultHotkeyPayloadJson(MainViewModelDefaults.ActionSetCredits);
-        var obj = JsonNode.Parse(json) as JsonObject;
+        var obj = JsonNode.Parse(json)!.AsObject();
 
         obj![MainViewModelDefaults.PayloadLockCredits]!.GetValue<bool>().Should().BeFalse();
         obj[MainViewModelDefaults.PayloadIntValue]!.GetValue<int>()
@@ -140,7 +140,7 @@ public sealed class MainViewModelHotkeyHelpersFullCoverageTests
     public void BuildDefaultHotkeyPayloadJson_FreezeSymbol_ShouldHaveFreezeKey()
     {
         var json = MainViewModelHotkeyHelpers.BuildDefaultHotkeyPayloadJson(MainViewModelDefaults.ActionFreezeSymbol);
-        var obj = JsonNode.Parse(json) as JsonObject;
+        var obj = JsonNode.Parse(json)!.AsObject();
 
         obj![MainViewModelDefaults.PayloadFreeze]!.GetValue<bool>().Should().BeTrue();
     }
@@ -149,7 +149,7 @@ public sealed class MainViewModelHotkeyHelpersFullCoverageTests
     public void BuildDefaultHotkeyPayloadJson_UnfreezeSymbol_ShouldHaveFreezeKeyFalse()
     {
         var json = MainViewModelHotkeyHelpers.BuildDefaultHotkeyPayloadJson(MainViewModelDefaults.ActionUnfreezeSymbol);
-        var obj = JsonNode.Parse(json) as JsonObject;
+        var obj = JsonNode.Parse(json)!.AsObject();
 
         obj![MainViewModelDefaults.PayloadFreeze]!.GetValue<bool>().Should().BeFalse();
     }
@@ -158,7 +158,7 @@ public sealed class MainViewModelHotkeyHelpersFullCoverageTests
     public void BuildDefaultHotkeyPayloadJson_SetGameSpeed_ShouldHaveFloatValue()
     {
         var json = MainViewModelHotkeyHelpers.BuildDefaultHotkeyPayloadJson(MainViewModelDefaults.ActionSetGameSpeed);
-        var obj = JsonNode.Parse(json) as JsonObject;
+        var obj = JsonNode.Parse(json)!.AsObject();
 
         obj![MainViewModelDefaults.PayloadFloatValue]!.GetValue<float>()
             .Should().Be(MainViewModelDefaults.DefaultGameSpeedValue);
@@ -168,7 +168,7 @@ public sealed class MainViewModelHotkeyHelpersFullCoverageTests
     public void BuildDefaultHotkeyPayloadJson_SetUnitCap_ShouldHaveEnableKey()
     {
         var json = MainViewModelHotkeyHelpers.BuildDefaultHotkeyPayloadJson(MainViewModelDefaults.ActionSetUnitCap);
-        var obj = JsonNode.Parse(json) as JsonObject;
+        var obj = JsonNode.Parse(json)!.AsObject();
 
         obj![MainViewModelDefaults.PayloadEnable]!.GetValue<bool>().Should().BeTrue();
         obj[MainViewModelDefaults.PayloadIntValue]!.GetValue<int>()

--- a/tests/SwfocTrainer.Tests/App/MainViewModelHotkeyHelpersWave5Tests.cs
+++ b/tests/SwfocTrainer.Tests/App/MainViewModelHotkeyHelpersWave5Tests.cs
@@ -115,7 +115,7 @@ public sealed class MainViewModelHotkeyHelpersWave5Tests
     public void BuildDefaultHotkeyPayloadJson_SetCredits_ShouldHaveCorrectKeys()
     {
         var json = MainViewModelHotkeyHelpers.BuildDefaultHotkeyPayloadJson(MainViewModelDefaults.ActionSetCredits);
-        var obj = JsonNode.Parse(json) as JsonObject;
+        var obj = JsonNode.Parse(json)!.AsObject();
         obj.Should().NotBeNull();
         obj![MainViewModelDefaults.PayloadSymbol]!.GetValue<string>().Should().Be("credits");
         obj[MainViewModelDefaults.PayloadIntValue]!.GetValue<int>().Should().Be(MainViewModelDefaults.DefaultCreditsValue);
@@ -126,7 +126,7 @@ public sealed class MainViewModelHotkeyHelpersWave5Tests
     public void BuildDefaultHotkeyPayloadJson_FreezeTimer_ShouldHaveBoolValueTrue()
     {
         var json = MainViewModelHotkeyHelpers.BuildDefaultHotkeyPayloadJson(MainViewModelDefaults.ActionFreezeTimer);
-        var obj = JsonNode.Parse(json) as JsonObject;
+        var obj = JsonNode.Parse(json)!.AsObject();
         obj.Should().NotBeNull();
         obj![MainViewModelDefaults.PayloadBoolValue]!.GetValue<bool>().Should().BeTrue();
     }
@@ -135,7 +135,7 @@ public sealed class MainViewModelHotkeyHelpersWave5Tests
     public void BuildDefaultHotkeyPayloadJson_SetGameSpeed_ShouldHaveFloatValue()
     {
         var json = MainViewModelHotkeyHelpers.BuildDefaultHotkeyPayloadJson(MainViewModelDefaults.ActionSetGameSpeed);
-        var obj = JsonNode.Parse(json) as JsonObject;
+        var obj = JsonNode.Parse(json)!.AsObject();
         obj.Should().NotBeNull();
         obj![MainViewModelDefaults.PayloadFloatValue]!.GetValue<float>().Should().Be(MainViewModelDefaults.DefaultGameSpeedValue);
     }
@@ -144,7 +144,7 @@ public sealed class MainViewModelHotkeyHelpersWave5Tests
     public void BuildDefaultHotkeyPayloadJson_UnfreezeSymbol_ShouldHaveFreezeFalse()
     {
         var json = MainViewModelHotkeyHelpers.BuildDefaultHotkeyPayloadJson(MainViewModelDefaults.ActionUnfreezeSymbol);
-        var obj = JsonNode.Parse(json) as JsonObject;
+        var obj = JsonNode.Parse(json)!.AsObject();
         obj.Should().NotBeNull();
         obj![MainViewModelDefaults.PayloadFreeze]!.GetValue<bool>().Should().BeFalse();
     }
@@ -153,7 +153,7 @@ public sealed class MainViewModelHotkeyHelpersWave5Tests
     public void BuildDefaultHotkeyPayloadJson_FreezeSymbol_ShouldHaveFreezeTrue()
     {
         var json = MainViewModelHotkeyHelpers.BuildDefaultHotkeyPayloadJson(MainViewModelDefaults.ActionFreezeSymbol);
-        var obj = JsonNode.Parse(json) as JsonObject;
+        var obj = JsonNode.Parse(json)!.AsObject();
         obj.Should().NotBeNull();
         obj![MainViewModelDefaults.PayloadFreeze]!.GetValue<bool>().Should().BeTrue();
         obj[MainViewModelDefaults.PayloadIntValue]!.GetValue<int>().Should().Be(MainViewModelDefaults.DefaultCreditsValue);
@@ -163,7 +163,7 @@ public sealed class MainViewModelHotkeyHelpersWave5Tests
     public void BuildDefaultHotkeyPayloadJson_ToggleInstantBuild_ShouldHaveEnableTrue()
     {
         var json = MainViewModelHotkeyHelpers.BuildDefaultHotkeyPayloadJson(MainViewModelDefaults.ActionToggleInstantBuildPatch);
-        var obj = JsonNode.Parse(json) as JsonObject;
+        var obj = JsonNode.Parse(json)!.AsObject();
         obj.Should().NotBeNull();
         obj![MainViewModelDefaults.PayloadEnable]!.GetValue<bool>().Should().BeTrue();
     }
@@ -172,7 +172,7 @@ public sealed class MainViewModelHotkeyHelpersWave5Tests
     public void BuildDefaultHotkeyPayloadJson_SetUnitCap_ShouldHaveCorrectValues()
     {
         var json = MainViewModelHotkeyHelpers.BuildDefaultHotkeyPayloadJson(MainViewModelDefaults.ActionSetUnitCap);
-        var obj = JsonNode.Parse(json) as JsonObject;
+        var obj = JsonNode.Parse(json)!.AsObject();
         obj.Should().NotBeNull();
         obj![MainViewModelDefaults.PayloadSymbol]!.GetValue<string>().Should().Be("unit_cap");
         obj[MainViewModelDefaults.PayloadIntValue]!.GetValue<int>().Should().Be(MainViewModelDefaults.DefaultUnitCapValue);

--- a/tests/SwfocTrainer.Tests/App/MainViewModelLiveOpsCoverageTests.cs
+++ b/tests/SwfocTrainer.Tests/App/MainViewModelLiveOpsCoverageTests.cs
@@ -561,7 +561,7 @@ public sealed class MainViewModelLiveOpsCoverageTests
     public void ApplyDraftFromSnapshot_NullSnapshot_ShouldThrow()
     {
         var vm = CreateViewModel();
-        var act = () => Invoke(vm, "ApplyDraftFromSnapshot", (SelectedUnitSnapshot)null!);
+        var act = () => Invoke(vm, "ApplyDraftFromSnapshot", default(SelectedUnitSnapshot));
         act.Should().Throw<TargetInvocationException>()
             .WithInnerException<ArgumentNullException>();
     }
@@ -602,7 +602,7 @@ public sealed class MainViewModelLiveOpsCoverageTests
     public void BuildActionContext_NullActionId_ShouldThrow()
     {
         var vm = CreateViewModel();
-        var act = () => Invoke(vm, "BuildActionContext", (string)null!);
+        var act = () => Invoke(vm, "BuildActionContext", default(string));
         act.Should().Throw<TargetInvocationException>()
             .WithInnerException<ArgumentNullException>();
     }

--- a/tests/SwfocTrainer.Tests/App/MainViewModelSaveOpsCoverageTests.cs
+++ b/tests/SwfocTrainer.Tests/App/MainViewModelSaveOpsCoverageTests.cs
@@ -609,7 +609,7 @@ public sealed class MainViewModelSaveOpsCoverageTests
     public void FlattenNodes_NullRoot_ShouldThrow()
     {
         var vm = CreateViewModel();
-        var act = () => InvokeProtected(vm, "FlattenNodes", (SaveNode)null!);
+        var act = () => InvokeProtected(vm, "FlattenNodes", default(SaveNode));
         act.Should().Throw<TargetInvocationException>()
             .WithInnerException<ArgumentNullException>();
     }
@@ -663,7 +663,7 @@ public sealed class MainViewModelSaveOpsCoverageTests
     public void PopulatePatchPreviewOperations_NullPreview_ShouldThrow()
     {
         var vm = CreateViewModel();
-        var act = () => InvokeProtected(vm, "PopulatePatchPreviewOperations", (SavePatchPreview)null!);
+        var act = () => InvokeProtected(vm, "PopulatePatchPreviewOperations", default(SavePatchPreview));
         act.Should().Throw<TargetInvocationException>()
             .WithInnerException<ArgumentNullException>();
     }
@@ -890,7 +890,7 @@ public sealed class MainViewModelSaveOpsCoverageTests
     public void AppendPatchArtifactRows_OnlyBackup_ShouldAddOne()
     {
         var vm = CreateViewModel();
-        InvokeProtected(vm, "AppendPatchArtifactRows", @"C:\backup.sav", (string?)null);
+        InvokeProtected(vm, "AppendPatchArtifactRows", @"C:\backup.sav", default(string));
 
         vm.SavePatchCompatibility.Should().HaveCount(1);
         vm.SavePatchCompatibility[0].Code.Should().Be("backup_path");

--- a/tests/SwfocTrainer.Tests/Core/CoreWave2CoverageTests.cs
+++ b/tests/SwfocTrainer.Tests/Core/CoreWave2CoverageTests.cs
@@ -255,7 +255,9 @@ public sealed class CoreWave2CoverageTests
         }
         finally
         {
-            try { Directory.Delete(customDir, true); } catch { /* best-effort cleanup */ }
+            try { Directory.Delete(customDir, true); }
+            catch (IOException) { /* best-effort cleanup */ }
+            catch (UnauthorizedAccessException) { /* best-effort cleanup */ }
         }
     }
 

--- a/tests/SwfocTrainer.Tests/Core/CoreWave6Tests.cs
+++ b/tests/SwfocTrainer.Tests/Core/CoreWave6Tests.cs
@@ -446,7 +446,6 @@ public sealed class CoreWave6Tests
     [Fact]
     public void ClampConfidence_NaN_ShouldReturn050()
     {
-        var service = new ActionReliabilityService();
         var mechanic = new FakeModMechanicDetectionService(new ModMechanicReport(
             "p1", DateTimeOffset.UtcNow, true, true,
             new[] { new ModMechanicSupport("set_credits", false, RuntimeReasonCode.CAPABILITY_REQUIRED_MISSING, "bad", double.NaN) },

--- a/tests/SwfocTrainer.Tests/Flow/FlowWave6Tests.cs
+++ b/tests/SwfocTrainer.Tests/Flow/FlowWave6Tests.cs
@@ -204,7 +204,7 @@ public sealed class FlowWave6Tests
         var flowReport = new FlowIndexReport(plots, Array.Empty<string>());
         var megaIndex = MegaFilesIndex.Empty;
 
-        var symbolPack = JsonSerializer.Serialize(new { Capabilities = (object?)null });
+        var symbolPack = JsonSerializer.Serialize(new { Capabilities = default(object) });
         var result = StoryPlotFlowExtractor.BuildCapabilityLinkReport(flowReport, megaIndex, symbolPack);
         result.Diagnostics.Should().Contain(d => d.Contains("missing"));
     }
@@ -393,7 +393,7 @@ public sealed class FlowWave6Tests
         {
             Capabilities = new object[]
             {
-                new { FeatureId = (string?)null, Available = true, State = "Active", ReasonCode = "OK" },
+                new { FeatureId = default(string), Available = true, State = "Active", ReasonCode = "OK" },
                 new { FeatureId = "set_credits", Available = true, State = "Active", ReasonCode = "OK" }
             }
         });
@@ -417,7 +417,7 @@ public sealed class FlowWave6Tests
         {
             Capabilities = new object[]
             {
-                new { FeatureId = "set_credits", Available = false, State = (string?)null, ReasonCode = (string?)null }
+                new { FeatureId = "set_credits", Available = false, State = default(string), ReasonCode = default(string) }
             }
         });
 

--- a/tests/SwfocTrainer.Tests/Flow/FlowWave7FinalTests.cs
+++ b/tests/SwfocTrainer.Tests/Flow/FlowWave7FinalTests.cs
@@ -39,7 +39,7 @@ public sealed class FlowWave7FinalTests
             BindingFlags.NonPublic | BindingFlags.Static);
         method.Should().NotBeNull("ResolveDefaultHarnessScriptPath must exist");
 
-        var result = method!.Invoke(null, Array.Empty<object>()) as string;
+        var result = method!.Invoke(null, Array.Empty<object>()) as string ?? throw new InvalidOperationException("test setup: expected non-null result.");
         result.Should().NotBeNullOrWhiteSpace();
         result!.Should().EndWith("run-lua-harness.ps1");
     }
@@ -103,7 +103,7 @@ public sealed class FlowWave7FinalTests
 
         var result = method!.Invoke(extractor, new object?[] { null, "test.xml" });
         result.Should().NotBeNull();
-        var events = result as IReadOnlyList<FlowEventRecord>;
+        var events = result as IReadOnlyList<FlowEventRecord> ?? throw new InvalidOperationException("test setup: expected non-null result.");
         events.Should().NotBeNull();
         events!.Should().BeEmpty();
     }

--- a/tests/SwfocTrainer.Tests/Helper/HelperModServiceFullCoverageTests.cs
+++ b/tests/SwfocTrainer.Tests/Helper/HelperModServiceFullCoverageTests.cs
@@ -138,7 +138,7 @@ public sealed class HelperModServiceFullCoverageTests
             });
 
             var service = CreateService(profile, sourceRoot, installRoot);
-            var result = await service.DeployAsync("test_profile");
+            await service.DeployAsync("test_profile");
             File.Exists(Path.Join(installRoot, "test_profile", "scripts", "hook.lua")).Should().BeTrue();
         }
         finally

--- a/tests/SwfocTrainer.Tests/Meg/MegArchiveReaderDeepBranchTests.cs
+++ b/tests/SwfocTrainer.Tests/Meg/MegArchiveReaderDeepBranchTests.cs
@@ -244,9 +244,8 @@ public sealed class MegArchiveReaderDeepBranchTests
         using var nameStream = new MemoryStream();
         using var nameWriter = new BinaryWriter(nameStream, Encoding.ASCII, leaveOpen: true);
         var names = new[] { "Z.txt", "A.txt" };
-        foreach (var name in names)
+        foreach (var nameBytes in names.Select(Encoding.ASCII.GetBytes))
         {
-            var nameBytes = Encoding.ASCII.GetBytes(name);
             nameWriter.Write((ushort)nameBytes.Length);
             nameWriter.Write((ushort)0);
             nameWriter.Write(nameBytes);

--- a/tests/SwfocTrainer.Tests/Meg/MegWave3FinalTests.cs
+++ b/tests/SwfocTrainer.Tests/Meg/MegWave3FinalTests.cs
@@ -372,12 +372,6 @@ public sealed class MegWave3FinalTests
     public void Open_Format3_WithNonZeroEntryFlags_ShouldFail()
     {
         // Build a valid format3 archive with 1 name, 1 file, but flags != 0
-        var nameBytes = Encoding.ASCII.GetBytes("test.xml");
-        var nameTableSize = (uint)(4 + nameBytes.Length);
-        uint nameCount = 1, fileCount = 1;
-        var dataStart = (24 + nameTableSize + 20);
-        var totalSize = (int)(dataStart + 10);
-        var bytes = new byte[totalSize];
 
         // Non-encrypted format3: first=0x8FFFFFFF to detect format3 variant,
         // but it's always encrypted. Use format2 instead for flag test.

--- a/tests/SwfocTrainer.Tests/Profiles/ProfilesWave7FinalTests.cs
+++ b/tests/SwfocTrainer.Tests/Profiles/ProfilesWave7FinalTests.cs
@@ -120,7 +120,7 @@ public sealed class ProfilesWave7FinalTests
         var result = method!.Invoke(null, new object[] { "testProfile", "/nonexistent/file.zip", "/tmp/extract" });
         // Should return a non-null ProfileInstallResult with failure
         result.Should().NotBeNull();
-        var installResult = result as ProfileInstallResult;
+        var installResult = result as ProfileInstallResult ?? throw new InvalidOperationException("test setup: expected non-null result.");
         installResult.Should().NotBeNull();
         installResult!.Succeeded.Should().BeFalse();
         installResult.ReasonCode.Should().Be("extract_failed");
@@ -150,7 +150,7 @@ public sealed class ProfilesWave7FinalTests
             Directory.CreateDirectory(extractDir);
             File.WriteAllText(Path.Join(extractDir, "old.txt"), "old");
 
-            var result = method!.Invoke(service, new object[] { "testprofile", "1.0" }) as string;
+            var result = method!.Invoke(service, new object[] { "testprofile", "1.0" }) as string ?? throw new InvalidOperationException("test setup: expected non-null result.");
             result.Should().NotBeNull();
             // The old directory contents should be gone (it was deleted)
             if (Directory.Exists(extractDir))

--- a/tests/SwfocTrainer.Tests/Runtime/ModDependencyValidatorBranchCoverageTests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/ModDependencyValidatorBranchCoverageTests.cs
@@ -889,7 +889,7 @@ public sealed class ModDependencyValidatorBranchCoverageTests
                 Directory.Delete(path, true);
             }
         }
-        catch (IOException) { }
-        catch (UnauthorizedAccessException) { }
+        catch (IOException) { /* best-effort test cleanup */ }
+        catch (UnauthorizedAccessException) { /* best-effort test cleanup */ }
     }
 }

--- a/tests/SwfocTrainer.Tests/Runtime/ProcessLocatorAdditionalBranchCoverageTests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/ProcessLocatorAdditionalBranchCoverageTests.cs
@@ -220,7 +220,7 @@ public sealed class ProcessLocatorAdditionalBranchCoverageTests
     [Fact]
     public void ExtractSteamModIds_ShouldReturnEmpty_ForNull()
     {
-        var result = (string[])InvokeStaticMethod("ExtractSteamModIds", (string?)null)!;
+        var result = (string[])InvokeStaticMethod("ExtractSteamModIds", default(string))!;
         result.Should().BeEmpty();
     }
 
@@ -518,7 +518,7 @@ public sealed class ProcessLocatorAdditionalBranchCoverageTests
     public async Task FindBestMatchAsync_Parameterless_ShouldReturnNull_WhenNoMatch()
     {
         var locator = new ProcessLocator();
-        var result = await locator.FindBestMatchAsync(ExeTarget.Swfoc);
+        await locator.FindBestMatchAsync(ExeTarget.Swfoc);
         // No game running in test env, just verify it doesn't throw
     }
 
@@ -526,7 +526,7 @@ public sealed class ProcessLocatorAdditionalBranchCoverageTests
     public async Task FindBestMatchAsync_WithToken_ShouldWork()
     {
         var locator = new ProcessLocator();
-        var result = await locator.FindBestMatchAsync(ExeTarget.Swfoc, CancellationToken.None);
+        await locator.FindBestMatchAsync(ExeTarget.Swfoc, CancellationToken.None);
         // No game running in test env
     }
 
@@ -534,7 +534,7 @@ public sealed class ProcessLocatorAdditionalBranchCoverageTests
     public async Task FindBestMatchAsync_WithNullOptions_ShouldDefault()
     {
         var locator = new ProcessLocator();
-        var result = await locator.FindBestMatchAsync(ExeTarget.Swfoc, null, CancellationToken.None);
+        await locator.FindBestMatchAsync(ExeTarget.Swfoc, null, CancellationToken.None);
         // Should not throw
     }
 

--- a/tests/SwfocTrainer.Tests/Runtime/ProcessLocatorBranchCoverageTests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/ProcessLocatorBranchCoverageTests.cs
@@ -430,7 +430,6 @@ public sealed class ProcessLocatorBranchCoverageTests
         var method = typeof(ProcessLocator).GetMethod("ResolveForcedContext", BindingFlags.Static | BindingFlags.NonPublic);
         method.Should().NotBeNull();
 
-        var optionsType = typeof(ProcessLocatorOptions);
         var options = new ProcessLocatorOptions(new[] { "99999" }, "forced_profile");
 
         var result = method!.Invoke(null, new object?[] { "cmd", "Mods/AOTR", new[] { "111" }, options });
@@ -506,7 +505,7 @@ public sealed class ProcessLocatorBranchCoverageTests
     {
         var locator = new ProcessLocator();
         // Most likely won't find swfoc in test environment, but should not throw
-        var result = await locator.FindBestMatchAsync(ExeTarget.Swfoc);
+        await locator.FindBestMatchAsync(ExeTarget.Swfoc);
         // result may be null, just shouldn't throw
     }
 

--- a/tests/SwfocTrainer.Tests/Runtime/ProcessMemoryAccessorTests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/ProcessMemoryAccessorTests.cs
@@ -62,32 +62,22 @@ public sealed class ProcessMemoryAccessorTests
     [Fact]
     public void ReadBytes_NegativeCount_ThrowsArgumentOutOfRangeException()
     {
-        var accessor = CreateWithHandle((nint)0xDEAD);
-        try
+        using var accessor = CreateWithHandle((nint)0xDEAD);
         {
             var act = () => accessor.ReadBytes((nint)0x1000, -1);
             act.Should().Throw<ArgumentOutOfRangeException>()
                 .WithParameterName("count");
-        }
-        finally
-        {
-            accessor.Dispose();
         }
     }
 
     [Fact]
     public void ReadBytes_InvalidHandle_ThrowsInvalidOperationException()
     {
-        var accessor = CreateWithHandle((nint)0xDEAD);
-        try
+        using var accessor = CreateWithHandle((nint)0xDEAD);
         {
             var act = () => accessor.ReadBytes((nint)0x1000, 4);
             act.Should().Throw<InvalidOperationException>()
                 .WithMessage("*ReadProcessMemory*");
-        }
-        finally
-        {
-            accessor.Dispose();
         }
     }
 
@@ -97,8 +87,7 @@ public sealed class ProcessMemoryAccessorTests
         // count = 0 is allowed (not negative). ReadProcessMemory with 0 bytes on an
         // invalid handle may either return true with 0 bytes read (matching count)
         // or return false. We only verify no ArgumentOutOfRangeException is thrown.
-        var accessor = CreateWithHandle((nint)0xDEAD);
-        try
+        using var accessor = CreateWithHandle((nint)0xDEAD);
         {
             try
             {
@@ -110,10 +99,6 @@ public sealed class ProcessMemoryAccessorTests
                 // Also acceptable — depends on OS behavior
             }
         }
-        finally
-        {
-            accessor.Dispose();
-        }
     }
 
     // ──────────────── Read<T> ────────────────
@@ -121,16 +106,11 @@ public sealed class ProcessMemoryAccessorTests
     [Fact]
     public void Read_InvalidHandle_ThrowsInvalidOperationException()
     {
-        var accessor = CreateWithHandle((nint)0xDEAD);
-        try
+        using var accessor = CreateWithHandle((nint)0xDEAD);
         {
             var act = () => accessor.Read<int>((nint)0x1000);
             act.Should().Throw<InvalidOperationException>()
                 .WithMessage("*ReadProcessMemory*");
-        }
-        finally
-        {
-            accessor.Dispose();
         }
     }
 
@@ -139,16 +119,11 @@ public sealed class ProcessMemoryAccessorTests
     [Fact]
     public void Write_InvalidHandle_ThrowsInvalidOperationException()
     {
-        var accessor = CreateWithHandle((nint)0xDEAD);
-        try
+        using var accessor = CreateWithHandle((nint)0xDEAD);
         {
             var act = () => accessor.Write((nint)0x1000, 42);
             act.Should().Throw<InvalidOperationException>()
                 .WithMessage("*WriteProcessMemory*");
-        }
-        finally
-        {
-            accessor.Dispose();
         }
     }
 
@@ -157,64 +132,44 @@ public sealed class ProcessMemoryAccessorTests
     [Fact]
     public void WriteBytes_NullBuffer_ThrowsArgumentNullException()
     {
-        var accessor = CreateWithHandle((nint)0xDEAD);
-        try
+        using var accessor = CreateWithHandle((nint)0xDEAD);
         {
             var act = () => accessor.WriteBytes((nint)0x1000, null!, false);
             act.Should().Throw<ArgumentNullException>().WithParameterName("buffer");
-        }
-        finally
-        {
-            accessor.Dispose();
         }
     }
 
     [Fact]
     public void WriteBytes_EmptyBuffer_ReturnsImmediately()
     {
-        var accessor = CreateWithHandle((nint)0xDEAD);
-        try
+        using var accessor = CreateWithHandle((nint)0xDEAD);
         {
             // Empty buffer → early return, no P/Invoke call
             var act = () => accessor.WriteBytes((nint)0x1000, Array.Empty<byte>(), false);
             act.Should().NotThrow();
-        }
-        finally
-        {
-            accessor.Dispose();
         }
     }
 
     [Fact]
     public void WriteBytes_NonEmptyBuffer_InvalidHandle_Throws()
     {
-        var accessor = CreateWithHandle((nint)0xDEAD);
-        try
+        using var accessor = CreateWithHandle((nint)0xDEAD);
         {
             var act = () => accessor.WriteBytes((nint)0x1000, new byte[] { 0x90 }, false);
             act.Should().Throw<InvalidOperationException>()
                 .WithMessage("*WriteProcessMemory*");
-        }
-        finally
-        {
-            accessor.Dispose();
         }
     }
 
     [Fact]
     public void WriteBytes_ExecutablePatch_InvalidHandle_Throws()
     {
-        var accessor = CreateWithHandle((nint)0xDEAD);
-        try
+        using var accessor = CreateWithHandle((nint)0xDEAD);
         {
             // executablePatch = true → tries VirtualProtectEx first
             var act = () => accessor.WriteBytes((nint)0x1000, new byte[] { 0x90 }, true);
             act.Should().Throw<InvalidOperationException>()
                 .WithMessage("*VirtualProtectEx*");
-        }
-        finally
-        {
-            accessor.Dispose();
         }
     }
 
@@ -223,45 +178,30 @@ public sealed class ProcessMemoryAccessorTests
     [Fact]
     public void Allocate_InvalidHandle_ReturnsZero()
     {
-        var accessor = CreateWithHandle((nint)0xDEAD);
-        try
+        using var accessor = CreateWithHandle((nint)0xDEAD);
         {
             var result = accessor.Allocate((nuint)4096, executable: false);
             result.Should().Be(nint.Zero);
-        }
-        finally
-        {
-            accessor.Dispose();
         }
     }
 
     [Fact]
     public void Allocate_Executable_InvalidHandle_ReturnsZero()
     {
-        var accessor = CreateWithHandle((nint)0xDEAD);
-        try
+        using var accessor = CreateWithHandle((nint)0xDEAD);
         {
             var result = accessor.Allocate((nuint)4096, executable: true);
             result.Should().Be(nint.Zero);
-        }
-        finally
-        {
-            accessor.Dispose();
         }
     }
 
     [Fact]
     public void Allocate_WithPreferredAddress_InvalidHandle_ReturnsZero()
     {
-        var accessor = CreateWithHandle((nint)0xDEAD);
-        try
+        using var accessor = CreateWithHandle((nint)0xDEAD);
         {
             var result = accessor.Allocate((nuint)4096, executable: false, preferredAddress: (nint)0x10000);
             result.Should().Be(nint.Zero);
-        }
-        finally
-        {
-            accessor.Dispose();
         }
     }
 
@@ -270,30 +210,20 @@ public sealed class ProcessMemoryAccessorTests
     [Fact]
     public void Free_ZeroAddress_ReturnsTrue()
     {
-        var accessor = CreateWithHandle((nint)0xDEAD);
-        try
+        using var accessor = CreateWithHandle((nint)0xDEAD);
         {
             var result = accessor.Free(nint.Zero);
             result.Should().BeTrue();
-        }
-        finally
-        {
-            accessor.Dispose();
         }
     }
 
     [Fact]
     public void Free_NonZeroAddress_InvalidHandle_ReturnsFalse()
     {
-        var accessor = CreateWithHandle((nint)0xDEAD);
-        try
+        using var accessor = CreateWithHandle((nint)0xDEAD);
         {
             var result = accessor.Free((nint)0x1000);
             result.Should().BeFalse();
-        }
-        finally
-        {
-            accessor.Dispose();
         }
     }
 

--- a/tests/SwfocTrainer.Tests/Runtime/RuntimeAdapterAsyncWave7Tests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/RuntimeAdapterAsyncWave7Tests.cs
@@ -1059,7 +1059,6 @@ public sealed class RuntimeAdapterAsyncWave7Tests
     public async Task ExecuteAsync_HelperRoute_MissingHook_ReturnsFailure()
     {
         // Create profile WITHOUT the hook ID the request references
-        var profile = BuildProfile("test_action");
         var actions = new Dictionary<string, ActionSpec>(StringComparer.OrdinalIgnoreCase)
         {
             ["test_action"] = new ActionSpec("test_action", ActionCategory.Hero, RuntimeMode.Unknown, ExecutionKind.Helper, new JsonObject(), false, 0)

--- a/tests/SwfocTrainer.Tests/Runtime/RuntimeAdapterBranchCoverageTests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/RuntimeAdapterBranchCoverageTests.cs
@@ -1285,7 +1285,7 @@ public sealed class RuntimeAdapterBranchCoverageTests
         // Success counters should have at least one entry
         var successCounters = typeof(RuntimeAdapter)
             .GetField("_actionSuccessCounters", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .GetValue(adapter) as Dictionary<string, int>;
+            .GetValue(adapter) as Dictionary<string, int> ?? throw new InvalidOperationException("test setup: expected non-null result.");
         successCounters.Should().NotBeNull();
         successCounters!.Values.Sum().Should().BeGreaterOrEqualTo(2);
     }

--- a/tests/SwfocTrainer.Tests/Runtime/RuntimeAdapterWave2CoverageTests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/RuntimeAdapterWave2CoverageTests.cs
@@ -770,7 +770,7 @@ public sealed class RuntimeAdapterWave2CoverageTests
         method.Should().NotBeNull();
 
         var primary = new Dictionary<string, object?> { ["a"] = "1" } as IReadOnlyDictionary<string, object?>;
-        var result = method!.Invoke(null, new object?[] { primary, null }) as IReadOnlyDictionary<string, object?>;
+        var result = method!.Invoke(null, new object?[] { primary, null }) as IReadOnlyDictionary<string, object?> ?? throw new InvalidOperationException("test setup: expected non-null result.");
         result.Should().NotBeNull();
         result!.Should().ContainKey("a");
     }
@@ -783,7 +783,7 @@ public sealed class RuntimeAdapterWave2CoverageTests
         method.Should().NotBeNull();
 
         var secondary = new Dictionary<string, object?> { ["b"] = "2" } as IReadOnlyDictionary<string, object?>;
-        var result = method!.Invoke(null, new object?[] { null, secondary }) as IReadOnlyDictionary<string, object?>;
+        var result = method!.Invoke(null, new object?[] { null, secondary }) as IReadOnlyDictionary<string, object?> ?? throw new InvalidOperationException("test setup: expected non-null result.");
         result.Should().NotBeNull();
         result!.Should().ContainKey("b");
     }

--- a/tests/SwfocTrainer.Tests/Runtime/RuntimeAdapterWave6Tests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/RuntimeAdapterWave6Tests.cs
@@ -487,7 +487,7 @@ public sealed class RuntimeAdapterWave6Tests
     public void TryReadBooleanPayload_ShouldReturnTrue_FromBoolNode()
     {
         var payload = new JsonObject { ["lockCredits"] = true };
-        var result = InvokeStatic("TryReadBooleanPayload", payload, "lockCredits", false);
+        InvokeStatic("TryReadBooleanPayload", payload, "lockCredits", false);
         // The method is `out bool` so we test via the adapter flow
     }
 
@@ -567,7 +567,7 @@ public sealed class RuntimeAdapterWave6Tests
     [Fact]
     public void ResolveManualOverrideMode_ShouldReturnNull_ForNullContext()
     {
-        var result = InvokeStatic("ResolveManualOverrideMode", (IReadOnlyDictionary<string, object?>?)null);
+        var result = InvokeStatic("ResolveManualOverrideMode", default(IReadOnlyDictionary<string, object?>));
         result.Should().BeNull();
     }
 
@@ -868,7 +868,7 @@ public sealed class RuntimeAdapterWave6Tests
     [Fact]
     public void ValidateObservedReadValue_ShouldPass_ForPointerType()
     {
-        var result = InvokeStatic("ValidateObservedReadValue", "test", "0x1000", SymbolValueType.Pointer, (SymbolValidationRule?)null);
+        var result = InvokeStatic("ValidateObservedReadValue", "test", "0x1000", SymbolValueType.Pointer, default(SymbolValidationRule));
         var isValid = result!.GetType().GetProperty("IsValid")!.GetValue(result);
         isValid.Should().Be(true);
     }
@@ -1000,7 +1000,7 @@ public sealed class RuntimeAdapterWave6Tests
     public void MergeAnchorMap_ShouldHandleNull()
     {
         var dest = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        InvokeStatic("MergeAnchorMap", dest, (object?)null);
+        InvokeStatic("MergeAnchorMap", dest, default(object));
         dest.Should().BeEmpty();
     }
 
@@ -1819,7 +1819,7 @@ public sealed class RuntimeAdapterWave6Tests
     [Fact]
     public void ResolveHybridExecutionFlag_ShouldReturnFalse_WhenNotPresent()
     {
-        var result = (bool)InvokeStatic("ResolveHybridExecutionFlag", (IReadOnlyDictionary<string, object?>?)null)!;
+        var result = (bool)InvokeStatic("ResolveHybridExecutionFlag", default(IReadOnlyDictionary<string, object?>))!;
         result.Should().BeFalse();
     }
 

--- a/tests/SwfocTrainer.Tests/Runtime/RuntimeInfraWave6Tests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/RuntimeInfraWave6Tests.cs
@@ -435,8 +435,6 @@ public sealed class RuntimeInfraWave6Tests : IDisposable
         var packPath = Path.Join(_tempRoot, "nofp.json");
         File.WriteAllText(packPath, """{"schemaVersion":"1.0"}""");
 
-        var packType = typeof(SignatureResolverSymbolHydration).GetNestedType(
-            "GhidraSymbolPackDto", BindingFlags.NonPublic);
         var args = new object?[] { Logger, packPath, null };
         var result = (bool)method!.Invoke(null, args)!;
         result.Should().BeFalse();
@@ -560,8 +558,6 @@ public sealed class RuntimeInfraWave6Tests : IDisposable
 
         var indexType = typeof(SignatureResolverSymbolHydration).GetNestedType(
             "GhidraArtifactIndexDto", BindingFlags.NonPublic);
-        var pointersType = typeof(SignatureResolverSymbolHydration).GetNestedType(
-            "GhidraArtifactPointersDto", BindingFlags.NonPublic);
 
         var index = Activator.CreateInstance(indexType!, new object?[] { null, null });
         var result = (bool)method!.Invoke(null, new[] { index, "some_fp" })!;
@@ -597,8 +593,6 @@ public sealed class RuntimeInfraWave6Tests : IDisposable
             "TryReadArtifactIndex", BindingFlags.NonPublic | BindingFlags.Static);
         method.Should().NotBeNull();
 
-        var indexType = typeof(SignatureResolverSymbolHydration).GetNestedType(
-            "GhidraArtifactIndexDto", BindingFlags.NonPublic);
         var args = new object?[] { Path.Join(_tempRoot, "nonexistent.json"), null };
         var result = (bool)method!.Invoke(null, args)!;
         result.Should().BeFalse();

--- a/tests/SwfocTrainer.Tests/Runtime/ValueFreezeServiceBranchCoverageTests.cs
+++ b/tests/SwfocTrainer.Tests/Runtime/ValueFreezeServiceBranchCoverageTests.cs
@@ -360,7 +360,7 @@ public sealed class ValueFreezeServiceBranchCoverageTests : IDisposable
     public async Task PulseCallback_ShouldNotWrite_WhenDisposed()
     {
         _runtime.SetAttached(true);
-        var svc = new ValueFreezeService(_runtime, _logger, 50);
+        using var svc = new ValueFreezeService(_runtime, _logger, 50);
         svc.FreezeInt("credits", 1000);
         svc.Dispose();
 
@@ -415,7 +415,7 @@ public sealed class ValueFreezeServiceBranchCoverageTests : IDisposable
     [Fact]
     public void Dispose_ShouldClearAllEntries()
     {
-        var svc = new ValueFreezeService(_runtime, _logger, int.MaxValue);
+        using var svc = new ValueFreezeService(_runtime, _logger, int.MaxValue);
         svc.FreezeInt("credits", 1000);
         svc.FreezeIntAggressive("fast", 2000);
         svc.Dispose();
@@ -426,7 +426,7 @@ public sealed class ValueFreezeServiceBranchCoverageTests : IDisposable
     [Fact]
     public void Dispose_CalledTwice_ShouldNotThrow()
     {
-        var svc = new ValueFreezeService(_runtime, _logger, int.MaxValue);
+        using var svc = new ValueFreezeService(_runtime, _logger, int.MaxValue);
         svc.Dispose();
         var act = () => svc.Dispose();
         act.Should().NotThrow();
@@ -435,7 +435,7 @@ public sealed class ValueFreezeServiceBranchCoverageTests : IDisposable
     [Fact]
     public void Dispose_ShouldStopAggressiveThread()
     {
-        var svc = new ValueFreezeService(_runtime, _logger, int.MaxValue);
+        using var svc = new ValueFreezeService(_runtime, _logger, int.MaxValue);
         svc.FreezeIntAggressive("credits", 1000);
         svc.Dispose();
         // Should not throw and aggressive thread should be stopped

--- a/tests/SwfocTrainer.Tests/Saves/SavePatchPackServiceBranchTests.cs
+++ b/tests/SwfocTrainer.Tests/Saves/SavePatchPackServiceBranchTests.cs
@@ -655,7 +655,7 @@ public sealed class SavePatchPackServiceBranchTests
     {
         var service = CreateService();
         var pack = await CreateMinimalPackAsync(service);
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
         cts.Cancel();
         var act = () => service.ValidateCompatibilityAsync(pack, MakeDoc(), "p", cts.Token);
         await act.Should().ThrowAsync<OperationCanceledException>();

--- a/tests/SwfocTrainer.Tests/Saves/SavesWave7FinalTests.cs
+++ b/tests/SwfocTrainer.Tests/Saves/SavesWave7FinalTests.cs
@@ -53,7 +53,7 @@ public sealed class SavesWave7FinalTests
         // int32 with non-numeric string triggers FormatException
         var operation = new SavePatchOperation(
             SavePatchOperationKind.SetValue, "/field", "f1", "int32", null, "not_a_number", 0);
-        var (value, failure) = InvokeTryNormalizePatchValue(helper, operation, "value_norm_failed");
+        var (_, failure) = InvokeTryNormalizePatchValue(helper, operation, "value_norm_failed");
         failure.Should().NotBeNull();
         failure!.Applied.Should().BeFalse();
     }


### PR DESCRIPTION
Drives **code-scanning to 0**. Fixes all 70 open CodeQL alerts in the test suite with real, behavior-preserving changes (no suppressions, no threshold changes). Production `src/` and coverage scope are untouched, so the 100% line+branch .NET coverage gate is unaffected.

Rule breakdown: missed-using (14)→`using var`; useless-upcast (14)→`default(T)`; useless-assignment (16)→drop dead locals/discard; dereferenced-may-be-null (18)→`!.AsObject()` / `as T ?? throw`; dispose/local-not-disposed (4)→`using var`; empty-catch (2)+catch-all (1)→specific catches w/ intent comments; linq/missed-select (1)→`.Select()`.

The single `src/` alert (cs/call-to-unmanaged-code: P/Invoke `ReadProcessMemory` in ProcessMemoryScanner) is dismissed as by-design (no managed cross-process memory-read API exists).

Local verification: `dotnet build` 0 errors; 1,306 modified-class tests pass, 0 failures. Full suite + nightly CodeQL rescan confirmed by CI.